### PR TITLE
Fix early prunning

### DIFF
--- a/src/emptiness_check.cpp
+++ b/src/emptiness_check.cpp
@@ -31,6 +31,12 @@ namespace kofola {
     emptiness_check::emptiness_check(inclusion_check *incl_checker):
     incl_checker_(incl_checker)
     {
+        if(kofola::OPTIONS.params.count("early_sim") != 0 && kofola::OPTIONS.params["early_sim"] == "yes") {
+            early_prune_ = true;
+        }
+        if(kofola::OPTIONS.params.count("early_plus_sim") != 0 && kofola::OPTIONS.params["early_plus_sim"] == "yes") {
+            early_prune_ = true;
+        }
     }
 
     bool emptiness_check::empty() {
@@ -103,8 +109,9 @@ namespace kofola {
 
         while(src_mstate != nullptr) {
             // early(+1) simul can decide nonemptiness
-            if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
+            if(early_prune_ && incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
                 return false;
+            dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
 
             bool recursion_like = false;
             while(!succs.empty()) {
@@ -223,7 +230,7 @@ namespace kofola {
 
         while(src_mstate != nullptr) {
             // early(+1) simul can decide nonemptiness
-            if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
+            if(early_prune_ && incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
                 return false;
             dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
             

--- a/src/emptiness_check.cpp
+++ b/src/emptiness_check.cpp
@@ -99,13 +99,13 @@ namespace kofola {
         auto succs = incl_checker_->get_succs(src_mstate);
         auto path_cond = spot::acc_cond::mark_t();
 
-        // early(+1) simul can decide nonemptiness
-        if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
-           return false;
-
         update_structures(src_mstate);
 
         while(src_mstate != nullptr) {
+            // early(+1) simul can decide nonemptiness
+            if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
+                return false;
+
             bool recursion_like = false;
             while(!succs.empty()) {
                 auto dst_mstate = succs.back();
@@ -183,6 +183,8 @@ namespace kofola {
             }
 
             // backtracking from recursion
+            if(!dfs_acc_stack_.empty())
+                dfs_acc_stack_.pop_back();
             src_mstate = src_mstates.top();
             src_mstates.pop();
             succs = successors.top();
@@ -196,7 +198,7 @@ namespace kofola {
 
     void emptiness_check::update_structures(const std::shared_ptr<inclusion_mstate>& src_mstate) {
         SCCs_.push(src_mstate);
-        dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
+        // dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
         dfs_num_[src_mstate] = index_;
         index_++;
         tarjan_stack_.push_back(src_mstate);
@@ -217,13 +219,14 @@ namespace kofola {
         auto succs = incl_checker_->get_succs(src_mstate);
         auto path_cond = spot::acc_cond::mark_t();
 
-        // early(+1) simul can decide nonemptiness
-        if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
-           return false;
-
         update_structures(src_mstate);
 
         while(src_mstate != nullptr) {
+            // early(+1) simul can decide nonemptiness
+            if(incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
+                return false;
+            dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
+            
             bool recursion_like = false;
             while(!succs.empty()) {
                 auto dst_mstate = succs.back();
@@ -269,6 +272,8 @@ namespace kofola {
                 remove_SCC(src_mstate);
             }
             // backtracking from recursion
+            if(!dfs_acc_stack_.empty())
+                dfs_acc_stack_.pop_back();
             src_mstate = src_mstates.top();
             src_mstates.pop();
             succs = successors.top();

--- a/src/emptiness_check.cpp
+++ b/src/emptiness_check.cpp
@@ -158,6 +158,9 @@ namespace kofola {
                         // same scenarios as for the exploration in original GS alg.
                         if(dfs_num_[jumping_dst_mstate] == UNDEFINED && !check_simul_less(jumping_dst_mstate))
                         {
+                            #ifdef ENABLE_COUNTER
+                                cnt_++;
+                            #endif
                             // recursion nesting
                             path_conds.push(path_cond);
                             path_cond |= jumping_dst_mstate->get_acc();

--- a/src/emptiness_check.hpp
+++ b/src/emptiness_check.hpp
@@ -95,6 +95,9 @@ namespace kofola
         bool decided_ = false;
         bool empty_ = true;
 
+        /// to know if early(+1) prunning should be used
+        bool early_prune_ = false;
+
         #ifdef ENABLE_COUNTER
             unsigned cnt_ = 0;
         #endif


### PR DESCRIPTION
Move early relation checks inside the loop of emptiness check. Fix dfs_acc_stack_ manipulation. Add flag to indicate when to call corresponding methods.  Certainly many optimizations can be made.