### PR TITLE
Fixed bugs

### DIFF
--- a/src/emptiness_check.cpp
+++ b/src/emptiness_check.cpp
@@ -111,7 +111,6 @@ namespace kofola {
             // early(+1) simul can decide nonemptiness
             if(early_prune_ && incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
                 return false;
-            dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
 
             bool recursion_like = false;
             while(!succs.empty()) {
@@ -131,6 +130,7 @@ namespace kofola {
 
                 if (dfs_num_[dst_mstate] == UNDEFINED && !check_simul_less(dst_mstate))
                 {
+                    dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
                     // recursion nesting
                     #ifdef ENABLE_COUNTER
                         cnt_++;
@@ -235,7 +235,6 @@ namespace kofola {
             // early(+1) simul can decide nonemptiness
             if(early_prune_ && incl_checker_->is_accepting(path_cond) && simulation_prunning(src_mstate))
                 return false;
-            dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
             
             bool recursion_like = false;
             while(!succs.empty()) {
@@ -256,6 +255,7 @@ namespace kofola {
 
                 if (dfs_num_[dst_mstate] == UNDEFINED)
                 {
+                    dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
                     #ifdef ENABLE_COUNTER
                         cnt_++;
                     #endif
@@ -297,10 +297,11 @@ namespace kofola {
 
     void emptiness_check::remove_SCC(const std::shared_ptr<inclusion_mstate> & src_mstate) {
         SCCs_.pop();
+        // dfs_acc_stack_.pop_back();
         std::shared_ptr<inclusion_mstate> tmp;
         do {
             tmp = tarjan_stack_.back(); tarjan_stack_.pop_back();
-            dfs_acc_stack_.pop_back();
+            // dfs_acc_stack_.pop_back();
             on_stack_[tmp] = false;
             empty_lang_states_[tmp->get_intersect_state().first].emplace_back(tmp); // when here, each state has empty language, otherwise we would have ended
         } while (src_mstate != tmp);
@@ -337,19 +338,23 @@ namespace kofola {
     bool emptiness_check::merge_acc_marks(const std::shared_ptr<inclusion_mstate> &dst_mstate) {
         spot::acc_cond::mark_t cond = dst_mstate->get_acc();
         std::shared_ptr<inclusion_mstate> tmp;
+        // SCCs_.push(dst_mstate);
         do {
             tmp = SCCs_.top(); SCCs_.pop();
-            bool root_encountered = dst_mstate->get_encountered();
-            if(root_encountered || dfs_num_[tmp] > dfs_num_[dst_mstate])
-                cond = (cond |= tmp->get_acc());
+            // bool root_encountered = dst_mstate->get_encountered();
+            if(dfs_num_[tmp] > dfs_num_[dst_mstate])
+                cond |= tmp->get_acc();
+            else {
+                cond |= tmp->accumulator_;
+            }
             if(incl_checker_->is_accepting(cond)){
                 decided_ = true;
                 empty_ = false;
                 return true;
             }
         } while(dfs_num_[tmp] > dfs_num_[dst_mstate]);
-        dst_mstate->set_encountered(true); // mark visited root
-        tmp->set_acc(cond);
+        // dst_mstate->set_encountered(true); // mark visited root
+        tmp->accumulator_ |= cond;
         SCCs_.push(tmp);
 
         return false;

--- a/src/emptiness_check.cpp
+++ b/src/emptiness_check.cpp
@@ -208,7 +208,6 @@ namespace kofola {
 
     void emptiness_check::update_structures(const std::shared_ptr<inclusion_mstate>& src_mstate) {
         SCCs_.push(src_mstate);
-        // dfs_acc_stack_.emplace_back(src_mstate, src_mstate->get_acc());
         dfs_num_[src_mstate] = index_;
         index_++;
         tarjan_stack_.push_back(src_mstate);
@@ -297,11 +296,9 @@ namespace kofola {
 
     void emptiness_check::remove_SCC(const std::shared_ptr<inclusion_mstate> & src_mstate) {
         SCCs_.pop();
-        // dfs_acc_stack_.pop_back();
         std::shared_ptr<inclusion_mstate> tmp;
         do {
             tmp = tarjan_stack_.back(); tarjan_stack_.pop_back();
-            // dfs_acc_stack_.pop_back();
             on_stack_[tmp] = false;
             empty_lang_states_[tmp->get_intersect_state().first].emplace_back(tmp); // when here, each state has empty language, otherwise we would have ended
         } while (src_mstate != tmp);
@@ -338,10 +335,8 @@ namespace kofola {
     bool emptiness_check::merge_acc_marks(const std::shared_ptr<inclusion_mstate> &dst_mstate) {
         spot::acc_cond::mark_t cond = dst_mstate->get_acc();
         std::shared_ptr<inclusion_mstate> tmp;
-        // SCCs_.push(dst_mstate);
         do {
             tmp = SCCs_.top(); SCCs_.pop();
-            // bool root_encountered = dst_mstate->get_encountered();
             if(dfs_num_[tmp] > dfs_num_[dst_mstate])
                 cond |= tmp->get_acc();
             else {
@@ -353,7 +348,6 @@ namespace kofola {
                 return true;
             }
         } while(dfs_num_[tmp] > dfs_num_[dst_mstate]);
-        // dst_mstate->set_encountered(true); // mark visited root
         tmp->accumulator_ |= cond;
         SCCs_.push(tmp);
 

--- a/src/inclusion_check.cpp
+++ b/src/inclusion_check.cpp
@@ -28,8 +28,10 @@ namespace kofola {
     }
 
     inclusion_check::inclusion_check(const spot::twa_graph_ptr &aut_A, const spot::twa_graph_ptr &aut_B)
-    : aut_A_(init_aut_A(aut_A)), aut_B_compl_(init_compl_aut_b(aut_B)),
-        support_(aut_A->num_states()), compat_(aut_A->num_states())
+    : aut_A_(init_aut_A(aut_A)), 
+      support_(aut_A_->num_states()), 
+      compat_(aut_A_->num_states()), 
+      aut_B_compl_(init_compl_aut_b(aut_B))
     {
         symbols_from_A(aut_A);
         // msupport_ = tmp_bdds.second;
@@ -291,8 +293,6 @@ namespace kofola {
         // extract A state and compl.B state from intersection macrostate to compute successors
         unsigned state_of_A = casted_src->state_.first;
         unsigned compl_state = casted_src->state_.second;
-
-        auto spot_s_A = aut_A_->state_from_number(state_of_A);
 
         bdd msupport = bddtrue;
         bdd n_s_compat = bddfalse;

--- a/src/inclusion_check.cpp
+++ b/src/inclusion_check.cpp
@@ -28,10 +28,12 @@ namespace kofola {
     }
 
     inclusion_check::inclusion_check(const spot::twa_graph_ptr &aut_A, const spot::twa_graph_ptr &aut_B)
-    : aut_A_(init_aut_A(aut_A)), aut_B_compl_(init_compl_aut_b(aut_B)){
-        auto tmp_bdds = symbols_from_A(aut_A_);
-        msupport_ = tmp_bdds.second;
-        n_s_compat_ = tmp_bdds.first;
+    : aut_A_(init_aut_A(aut_A)), aut_B_compl_(init_compl_aut_b(aut_B)),
+        support_(aut_A->num_states()), compat_(aut_A->num_states())
+    {
+        symbols_from_A(aut_A);
+        // msupport_ = tmp_bdds.second;
+        // n_s_compat_ = tmp_bdds.first;
 
         unsigned init_A = aut_A_->get_init_state_number();
 
@@ -225,20 +227,17 @@ namespace kofola {
         return aut_reduced;
     }
 
-    std::pair<bdd, bdd> inclusion_check::symbols_from_A(const spot::twa_graph_ptr &aut_A) {
-        // taken from complement_sync
-        bdd res = bddfalse;
-        bdd msupport = bddtrue;
-
-        for (unsigned s = 0; s < aut_A->num_states(); s++) {
-            for (const auto &t: aut_A->out(s)) {
-                res |= t.cond;
-                msupport &= bdd_support(t.cond);
-                DEBUG_PRINT_LN("automaton alphabet symbol: " + std::to_string(t.cond));
+    void inclusion_check::symbols_from_A(const spot::twa_graph_ptr &aut_A) {
+        for (unsigned i = 0; i < aut_A->num_states(); ++i) {
+            bdd res_support = bddtrue;
+            bdd res_compat = bddfalse;
+            for (const auto &out: aut_A->out(i)) {
+                res_support &= bdd_support(out.cond);
+                res_compat |= out.cond;
             }
+            support_[i] = res_support;
+            compat_[i] = res_compat;
         }
-
-        return std::make_pair(res, msupport);
     }
 
     void inclusion_check::print_mstate(const std::shared_ptr<inclusion_mstate> a) {
@@ -276,12 +275,10 @@ namespace kofola {
         }
         // if not computed yet, compute
         if(succs_B.empty()) {
-            // std::cout << std::to_string(compl_state) << " , " << std::to_string(letter) << "\n";
             const cola::tnba_complement::uberstate &us_B = aut_B_compl_.num_to_uberstate(compl_state);
             succs_B = aut_B_compl_.get_succ_uberstates(us_B, letter);
             compl_state_storage_[compl_state].emplace_back(std::pair(succs_B, letter));
         }
-
         return succs_B;
     }
 
@@ -294,43 +291,39 @@ namespace kofola {
         // extract A state and compl.B state from intersection macrostate to compute successors
         unsigned state_of_A = casted_src->state_.first;
         unsigned compl_state = casted_src->state_.second;
-        
-        bdd all = n_s_compat_;
-        struct BDDComparator {
-            bool operator()(const bdd& a, const bdd& b) const {
-                return a.id() < b.id();
-            }
-        };
 
         auto spot_s_A = aut_A_->state_from_number(state_of_A);
-        std::map<bdd, std::set<unsigned>,BDDComparator> cond_to_states;
-        for (auto i: aut_A_->succ(spot_s_A)) {
-            if (cond_to_states.count(i->cond()) == 0)
-                cond_to_states[i->cond()] = {};
-        
-            cond_to_states[i->cond()].emplace(aut_A_->state_number(i->dst()));
-        }
 
-        for (auto const& i: cond_to_states) {
-            get_successors_compl(compl_state, i.first);
-            std::set<unsigned> succs_A = i.second;
-            if(succs_A.empty())
-                continue;
+        bdd msupport = bddtrue;
+        bdd n_s_compat = bddfalse;
+
+        msupport &= support_[state_of_A];
+        n_s_compat |= compat_[state_of_A];
+
+        bdd all = n_s_compat;
+
+
+        while(all != bddfalse) {
+            bdd letter = bdd_satoneset(all, msupport,bddfalse);
+            all -= letter;
+            std::vector<unsigned> myVector = {state_of_A};
+            std::set<unsigned> succs_A = get_all_successors(aut_A_,myVector,letter);
+            // if(succs_A.empty())
+            //     continue;
 
             cola::tnba_complement::vec_state_taggedcol succs_B;
             if(!aut_B_compl_.get_is_sink_created() || compl_state != aut_B_compl_.get_sink_state())
             {
-                succs_B = get_successors_compl(compl_state, i.first);
+                succs_B = get_successors_compl(compl_state, letter);
             }
             else
             {
                 succs_B.push_back({aut_B_compl_.get_sink_state(), {}});
             }
-            
             if(!succs_A.empty() && !succs_B.empty())
             {
                 cartesian_prod = get_cartesian_prod(state_of_A, succs_A, succs_B,
-                                                    i.first);
+                    letter);
                 for (auto& succ : cartesian_prod) {
                     result.emplace_back(std::move(succ));
                 }

--- a/src/inclusion_check.hpp
+++ b/src/inclusion_check.hpp
@@ -24,11 +24,13 @@ namespace kofola {
     private:
         intersect_mstate state_;
         spot::acc_cond::mark_t acc_; /// acc. marks on transition incoming to the state
+        spot::acc_cond::mark_t accumulator_;
         bdd trans_cond_; /// transition condition to come to this state
         bool encountered_ = false;
     public:
         inclusion_mstate() {
-            ;
+            acc_ = spot::acc_cond::mark_t{};
+            accumulator_ = spot::acc_cond::mark_t{};
         }
 
         spot::acc_cond::mark_t get_acc() {return acc_; }
@@ -40,14 +42,14 @@ namespace kofola {
         /// equality of inclusion macrostates
         bool eq(const inclusion_mstate& rhs) const {
             const auto *rhs_incl_ms = dynamic_cast<const inclusion_mstate*>(&rhs);
-            return (state_ == rhs_incl_ms->state_ && acc_ == rhs_incl_ms->acc_);
+            return (state_ == rhs_incl_ms->state_);
         }
 
         /// ordering of inclusion macrostate
         bool lt(const inclusion_mstate& rhs) const {
             const auto *rhs_incl_ms = dynamic_cast<const inclusion_mstate*>(&rhs);
             if(state_ != rhs_incl_ms->state_) {return state_ < rhs_incl_ms->state_;}
-            else {return acc_ < rhs_incl_ms->acc_;}
+            // else {return acc_ < rhs_incl_ms->acc_;}
 
             return false;
         }
@@ -57,6 +59,7 @@ namespace kofola {
         const intersect_mstate& get_intersect_state() const { return state_; }
 
         friend class inclusion_check;
+        friend class emptiness_check;
     };
 
     /// main class for on the fly inclussion procedure
@@ -76,8 +79,8 @@ namespace kofola {
 
         std::vector<std::shared_ptr<kofola::inclusion_mstate>> init_states_;
         spot::twa_graph_ptr aut_A_;
-        bdd msupport_;
-        bdd n_s_compat_;
+        std::vector<bdd> support_;
+        std::vector<bdd> compat_;
         cola::tnba_complement aut_B_compl_;
         /// acc_cond that should be satisfied for inclusion to not hold
         spot::acc_cond::acc_code acc_cond_;
@@ -119,7 +122,7 @@ namespace kofola {
         spot::twa_graph_ptr preprocess(const spot::twa_graph_ptr &aut);
 
         /// returns "alphabet" of automaton aut_A
-        std::pair<bdd, bdd> symbols_from_A(const spot::twa_graph_ptr &aut_A);
+        void symbols_from_A(const spot::twa_graph_ptr &aut_A);
 
         /// implements getter fot initial states, so the emptiness check can obtain them
         std::vector<std::shared_ptr<inclusion_mstate>> get_initial_states();


### PR DESCRIPTION
This pull request addresses the following issues:
- merging 'colors' when a cycle is found in an SCC should now correctly prevent ambiguities related to accepting transitions entering the root node of the cycle,
- when computing successors for inclusion macrostates, precomputed minterms for individual states of automaton A are used,
- less '<' operator for inclusion macrostates was originally correct (the incorrect fix was in the commit 91e3d4403352586706502538ce398ff0951888dc).