### PR TITLE
Fix: TELA inductive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,16 +34,18 @@ jobs:
             libgmp-dev libreadline-dev libunistring-dev texinfo
       - name: Install Spot ${SPOT_VERSION}
         run: |
-          url="https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz"
+          # LRDE publishes e.g. spot-2.14.tar.gz, not spot-2.14.0.tar.gz
+          spot_tar_ver="${SPOT_VERSION%.0}"
+          url="https://www.lrde.epita.fr/dload/spot/spot-${spot_tar_ver}.tar.gz"
           curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
           tar -xzf spot.tar.gz
-          cd "spot-${SPOT_VERSION}" 
+          cd "spot-${spot_tar_ver}" 
           ./configure
           make -j"$(nproc)"
           sudo make install
 
           # Sanity-check the installed version
-          autfilt --version | head -n 1 | grep -F "${SPOT_VERSION}"
+          autfilt --version | head -n 1 | grep -E "${SPOT_VERSION}|${spot_tar_ver}"
       - name: Compile release
         run: make release
       - name: Test release
@@ -67,16 +69,18 @@ jobs:
           brew install autoconf automake libtool pkg-config bison flex gmp readline libunistring texinfo
       - name: Install Spot ${SPOT_VERSION}
         run: |
-          url="https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz"
+          # LRDE publishes e.g. spot-2.14.tar.gz, not spot-2.14.0.tar.gz
+          spot_tar_ver="${SPOT_VERSION%.0}"
+          url="https://www.lrde.epita.fr/dload/spot/spot-${spot_tar_ver}.tar.gz"
           curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
           tar -xzf spot.tar.gz
-          cd "spot-${SPOT_VERSION}"
+          cd "spot-${spot_tar_ver}"
           ./configure
           make -j"$(sysctl -n hw.ncpu)"
           sudo make install
 
           # Sanity-check the installed version
-          autfilt --version | head -n 1 | grep -F "${SPOT_VERSION}"
+          autfilt --version | head -n 1 | grep -E "${SPOT_VERSION}|${spot_tar_ver}"
       - name: Compile
         run: make release
       - name: Test the library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake wget \
+            ca-certificates curl \
             autoconf automake libtool pkg-config \
             bison flex \
             python3 python3-dev swig \
             libgmp-dev libreadline-dev libunistring-dev texinfo
       - name: Install Spot ${SPOT_VERSION}
         run: |
-          wget -qO- "https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz" | tar -xz
-          cd "spot-${SPOT_VERSION}"
+          url="https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
+          tar -xzf spot.tar.gz
+          cd "spot-${SPOT_VERSION}" 
           ./configure
           make -j"$(nproc)"
           sudo make install
@@ -64,7 +67,9 @@ jobs:
           brew install autoconf automake libtool pkg-config bison flex gmp readline libunistring texinfo
       - name: Install Spot ${SPOT_VERSION}
         run: |
-          curl -fsSL "https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz" | tar -xz
+          url="https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
+          tar -xzf spot.tar.gz
           cd "spot-${SPOT_VERSION}"
           ./configure
           make -j"$(sysctl -n hw.ncpu)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,18 +17,30 @@ jobs:
   ubuntu-build:
     name: "Ubuntu (build-&-test)"
     runs-on: ubuntu-22.04
+    env:
+      SPOT_VERSION: 2.14.0
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake wget gnupg
-      - name: Install Spot dependencies
+          sudo apt-get install -y \
+            build-essential cmake wget \
+            autoconf automake libtool pkg-config \
+            bison flex \
+            python3 python3-dev swig \
+            libgmp-dev libreadline-dev libunistring-dev texinfo
+      - name: Install Spot ${SPOT_VERSION}
         run: |
-          sudo sh -c "echo 'deb [trusted=true] https://download.opensuse.org/repositories/home:/adl/xUbuntu_22.04/ ./' >> /etc/apt/sources.list"
-          sudo apt-get update
-          sudo apt-get install spot libspot-dev spot-doc python3-spot
+          wget -qO- "https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz" | tar -xz
+          cd "spot-${SPOT_VERSION}"
+          ./configure
+          make -j"$(nproc)"
+          sudo make install
+
+          # Sanity-check the installed version
+          autfilt --version | head -n 1 | grep -F "${SPOT_VERSION}"
       - name: Compile release
         run: make release
       - name: Test release
@@ -42,13 +54,24 @@ jobs:
   macos-build:
     name: "MacOS (build-&-test)"
     runs-on: macos-26
+    env:
+      SPOT_VERSION: 2.14.0
     steps:
       - uses: actions/checkout@v4
       - name: Building MacOS dependencies
         run: |
           brew update
-          brew uninstall --force spot || true
-          HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source spot
+          brew install autoconf automake libtool pkg-config bison flex gmp readline libunistring texinfo
+      - name: Install Spot ${SPOT_VERSION}
+        run: |
+          curl -fsSL "https://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz" | tar -xz
+          cd "spot-${SPOT_VERSION}"
+          ./configure
+          make -j"$(sysctl -n hw.ncpu)"
+          sudo make install
+
+          # Sanity-check the installed version
+          autfilt --version | head -n 1 | grep -F "${SPOT_VERSION}"
       - name: Compile
         run: make release
       - name: Test the library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,35 +17,18 @@ jobs:
   ubuntu-build:
     name: "Ubuntu (build-&-test)"
     runs-on: ubuntu-22.04
-    env:
-      SPOT_VERSION: 2.14.0
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            build-essential cmake wget \
-            ca-certificates curl \
-            autoconf automake libtool pkg-config \
-            bison flex \
-            python3 python3-dev swig \
-            libgmp-dev libreadline-dev libunistring-dev texinfo
-      - name: Install Spot ${SPOT_VERSION}
+          sudo apt-get install -y build-essential cmake wget gnupg
+      - name: Install Spot dependencies
         run: |
-          # LRDE publishes e.g. spot-2.14.tar.gz, not spot-2.14.0.tar.gz
-          spot_tar_ver="${SPOT_VERSION%.0}"
-          url="https://www.lrde.epita.fr/dload/spot/spot-${spot_tar_ver}.tar.gz"
-          curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
-          tar -xzf spot.tar.gz
-          cd "spot-${spot_tar_ver}" 
-          ./configure
-          make -j"$(nproc)"
-          sudo make install
-
-          # Sanity-check the installed version
-          autfilt --version | head -n 1 | grep -E "${SPOT_VERSION}|${spot_tar_ver}"
+          sudo sh -c "echo 'deb [trusted=true] https://download.opensuse.org/repositories/home:/adl/xUbuntu_22.04/ ./' >> /etc/apt/sources.list"
+          sudo apt-get update
+          sudo apt-get install spot libspot-dev spot-doc python3-spot
       - name: Compile release
         run: make release
       - name: Test release
@@ -59,28 +42,13 @@ jobs:
   macos-build:
     name: "MacOS (build-&-test)"
     runs-on: macos-26
-    env:
-      SPOT_VERSION: 2.14.0
     steps:
       - uses: actions/checkout@v4
       - name: Building MacOS dependencies
         run: |
           brew update
-          brew install autoconf automake libtool pkg-config bison flex gmp readline libunistring texinfo
-      - name: Install Spot ${SPOT_VERSION}
-        run: |
-          # LRDE publishes e.g. spot-2.14.tar.gz, not spot-2.14.0.tar.gz
-          spot_tar_ver="${SPOT_VERSION%.0}"
-          url="https://www.lrde.epita.fr/dload/spot/spot-${spot_tar_ver}.tar.gz"
-          curl -fL --retry 5 --retry-all-errors --retry-delay 2 -o spot.tar.gz "$url"
-          tar -xzf spot.tar.gz
-          cd "spot-${spot_tar_ver}"
-          ./configure
-          make -j"$(sysctl -n hw.ncpu)"
-          sudo make install
-
-          # Sanity-check the installed version
-          autfilt --version | head -n 1 | grep -E "${SPOT_VERSION}|${spot_tar_ver}"
+          brew uninstall --force spot || true
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source spot
       - name: Compile
         run: make release
       - name: Test the library

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -68,12 +68,13 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
-  const bdd&                        bdd) const {
+  const bdd&                        bdd,
+  bool                              resample) const {
 
   if (this->is_leaf()) {
     return std::visit(
       [&](const auto& leaf) {
-        return leaf.get_succ(aut, scc_info, check_states, bdd);
+        return leaf.get_succ(aut, scc_info, check_states, bdd, resample);
       },
       this->leaf_value());
   }
@@ -83,8 +84,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   const check_macrostate right_ms(base_tree(this->right()));
 
   if (node_type == TreeType::And) {
-    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd);
-    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd);
+    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample);
+    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample);
     return cartesian_product<check_macrostate, check_macrostate>(
       left_succ,
       right_succ,
@@ -102,8 +103,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       }
       const auto& left_states = part[0];
       const auto& right_states = part[1];
-      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd);
-      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd);
+      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd, resample);
+      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample);
 
       // TODO: it is not efficient to call reduce here
       const auto combined = cartesian_product<check_macrostate, check_macrostate>(
@@ -424,8 +425,10 @@ std::vector<check_macrostate> fin_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
-  const bdd&                        bdd) const {
+  const bdd&                        bdd,
+  bool                              resample) const {
 
+  (void)resample; // unused
   std::set<unsigned> st = get_set_union(this->safe, check_states);
   std::set<unsigned> succs {};
   for (unsigned s : st) {
@@ -475,7 +478,8 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
-  const bdd&                        bdd) const {
+  const bdd&                        bdd,
+  bool                              resample) const {
 
   std::set<unsigned> st = get_set_union(this->track, check_states);
   std::set<unsigned> succs {};
@@ -488,7 +492,7 @@ std::vector<check_macrostate> inf_leaf::get_succ(
     }
   }
 
-  if (check_states.empty()) {
+  if (!resample) {
     for (unsigned s : this->breakpoint) {
       for (const auto& t : aut->out(s)) {
         if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
@@ -638,10 +642,10 @@ mstate_col_set complement_sd_inductive::get_succ_active(
   std::set<unsigned> succ_check = kofola::get_all_successors_in_scc(
       this->info_.aut_, this->info_.scc_info_, src_mst->check_, symbol);
   std::vector<sd_inductive::check_macrostate> succ_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
-      this->info_.scc_info_, empty, symbol);
+      this->info_.scc_info_, empty, symbol, false);
   if(src_mst->type_ == sd_inductive::mstate_type::GUESS) {
     std::vector<sd_inductive::check_macrostate> succ_check_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
-      this->info_.scc_info_, src_mst->check_, symbol);
+      this->info_.scc_info_, src_mst->check_, symbol, true);
     for(const auto& tree : succ_trees) {
       std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
           succ_check, tree, sd_inductive::mstate_type::GUESS));

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -85,7 +85,8 @@ namespace sd_inductive {
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
-      const bdd&                        bdd) const;
+      const bdd&                        bdd,
+      bool                              resample) const;
 
     bool is_satisfied() const;
   };
@@ -139,7 +140,8 @@ namespace sd_inductive {
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
-      const bdd&                        bdd) const;
+      const bdd&                        bdd,
+      bool                              resample) const;
 
     bool is_satisfied() const;
 
@@ -285,7 +287,8 @@ namespace sd_inductive {
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
-      const bdd&                        bdd) const;
+      const bdd&                        bdd,
+      bool                              resample) const;
 
     /// Check whether this macrostate check tree is satisfied.
     bool is_satisfied() const;

--- a/src/complement/complement_sync.cpp
+++ b/src/complement/complement_sync.cpp
@@ -1018,6 +1018,9 @@ namespace helpers {
         if (is_buchi) {
             return std::make_unique<kofola::complement_ncsb>(*(this->info_.get()), partition_index);
         } else {
+            if (kofola::has_value("tela_det_alg", "inductive", kofola::OPTIONS.params)) {
+                return std::make_unique<kofola::complement_sd_inductive>(*(this->info_.get()), partition_index);
+            }
             return std::make_unique<kofola::complement_sd_tela>(*(this->info_.get()), partition_index);
         }
     } // create_strongly_deterministic_algorithm() }}}

--- a/tests/test_data/tela_det/out_1332.hoa
+++ b/tests/test_data/tela_det/out_1332.hoa
@@ -1,0 +1,19 @@
+HOA: v1
+States: 3
+Start: 0
+AP: 2 "a" "b"
+Acceptance: 4 Fin(2) & (Inf(1) | Fin(0)) & Inf(3)
+properties: trans-labels explicit-labels trans-acc complete
+properties: semi-deterministic
+--BODY--
+State: 0
+[t] 0
+[0] 1
+[!0] 2
+State: 1
+[!1] 1 {0 3}
+[1] 1 {1 3}
+State: 2
+[1] 2 {2}
+[!1] 2 {3}
+--END--

--- a/tests/test_data/tela_det/out_3357.hoa
+++ b/tests/test_data/tela_det/out_3357.hoa
@@ -1,0 +1,25 @@
+HOA: v1
+States: 3
+Start: 0
+AP: 3 "a" "b" "c"
+Acceptance: 5 (Inf(3) | Fin(2)) & Fin(1) & (Inf(4) | Fin(0))
+properties: trans-labels explicit-labels trans-acc complete
+properties: semi-deterministic
+--BODY--
+State: 0
+[t] 0 {0}
+[1] 1
+[!1] 2
+State: 1
+[!0&1&!2] 1
+[!1&!2] 1 {0}
+[2] 1 {1}
+[0&1&!2] 1 {4}
+State: 2
+[!0&!1&!2] 2 {2}
+[1&!2] 2 {0 2}
+[!0&!1&2] 2 {3}
+[1&2] 2 {0 3}
+[0&!1&!2] 2 {2 4}
+[0&!1&2] 2 {3 4}
+--END--

--- a/tests/utils/test_utils.hpp
+++ b/tests/utils/test_utils.hpp
@@ -90,7 +90,8 @@ const std::vector<std::string> COMMON_TEST_FILES = {
     "tests/test_data/tela_det/automaton860.hoa",
     "tests/test_data/tela_det/automaton90.hoa",
     "tests/test_data/tela_det/automaton900.hoa",
-    "tests/test_data/tela_det/automaton940.hoa"
+    "tests/test_data/tela_det/automaton940.hoa",
+    "tests/test_data/tela_det/out_1332.hoa",
 };
 
 /**

--- a/tests/utils/test_utils.hpp
+++ b/tests/utils/test_utils.hpp
@@ -92,7 +92,7 @@ const std::vector<std::string> COMMON_TEST_FILES = {
     "tests/test_data/tela_det/automaton900.hoa",
     "tests/test_data/tela_det/automaton940.hoa",
     "tests/test_data/tela_det/out_1332.hoa",
-    "tests/test_data/tela_det/out_3357.hoa",
+    //"tests/test_data/tela_det/out_3357.hoa",
 };
 
 /**

--- a/tests/utils/test_utils.hpp
+++ b/tests/utils/test_utils.hpp
@@ -92,6 +92,7 @@ const std::vector<std::string> COMMON_TEST_FILES = {
     "tests/test_data/tela_det/automaton900.hoa",
     "tests/test_data/tela_det/automaton940.hoa",
     "tests/test_data/tela_det/out_1332.hoa",
+    "tests/test_data/tela_det/out_3357.hoa",
 };
 
 /**


### PR DESCRIPTION
This pull request fixes the TELA inductive complementation algorithm by introducing a new `resample` parameter to the `get_succ` methods, allowing more control over successor generation in various macrostate and leaf classes. It also adds a new test automaton to the test suite to ensure correctness. 
