### PR TITLE
Params: add `dnf-tela` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The complementation and the inclusion checking might be adjusted by the followin
 | `gfee` | `yes`,`no`  | Use a good for emptiness relation for early termination (`--inclusion` only) |
 | `tela` | `yes`,`no`  | If `yes`, use TELA-specific algorithms for complementation (if `no`, the input is converted to TBA) |
 | `sh-break` | `yes`,`no`  | Enable shared breakpoint across partial algorithms; when `yes` partial algorithms that support shared breakpoints propagate a common breakpoint across partitions |
-| `tela_det_alg` | `inductive` | Algorithm selection for complementing deterministic TELA components | 
+| `tela_det_alg` | `inductive`, `dnf-tela` | Algorithm selection for complementing deterministic TELA components (default `dnf-tela`) | 
 
 ## Testing
 

--- a/src/complement/complement_sync.cpp
+++ b/src/complement/complement_sync.cpp
@@ -998,6 +998,8 @@ namespace helpers {
         } else {
             if (kofola::has_value("tela_det_alg", "inductive", kofola::OPTIONS.params)) {
                 return std::make_unique<kofola::complement_sd_inductive>(*(this->info_.get()), partition_index);
+            } else if(kofola::has_value("tela_det_alg", "dnf-tela", kofola::OPTIONS.params)) {
+                return std::make_unique<kofola::complement_sd_tela>(*(this->info_.get()), partition_index);
             }
             return std::make_unique<kofola::complement_sd_tela>(*(this->info_.get()), partition_index);
         }
@@ -1023,6 +1025,8 @@ namespace helpers {
         } else {
             if (kofola::has_value("tela_det_alg", "inductive", kofola::OPTIONS.params)) {
                 return std::make_unique<kofola::complement_sd_inductive>(*(this->info_.get()), partition_index);
+            } else if(kofola::has_value("tela_det_alg", "dnf-tela", kofola::OPTIONS.params)) {
+                return std::make_unique<kofola::complement_sd_tela>(*(this->info_.get()), partition_index);
             }
             return std::make_unique<kofola::complement_sd_tela>(*(this->info_.get()), partition_index);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,6 +277,10 @@ int main(int argc, char *argv[])
 
 	if(kofola::OPTIONS.params.count("merge_iwa") == 0) kofola::OPTIONS.params["merge_iwa"] = "yes";
 	if(kofola::OPTIONS.params.count("merge_det") == 0) kofola::OPTIONS.params["merge_det"] = "yes";
+	if(kofola::OPTIONS.params.count("tela") != 0 && kofola::OPTIONS.params["tela"] == "yes") {
+		// Default: dnf-tela for TELA complementation
+		if(kofola::OPTIONS.params.count("tela_det_alg") == 0) kofola::OPTIONS.params["tela_det_alg"] = "dnf-tela";
+	}
 	// Default: enable simulation-based macrostate pruning unless user specified otherwise.
 	// (May be internally turned off for very large automata in the construction code.)
 	if(options.operation != "inclusion" && kofola::OPTIONS.params.count("sim-ms-prune") == 0) kofola::OPTIONS.params["sim-ms-prune"] = "yes";


### PR DESCRIPTION
This pull request updates the handling of the `tela_det_alg` parameter for TELA complementation, providing users with more explicit control over the algorithm selection and updating defaults accordingly. The changes introduce the `dnf-tela` algorithm as a selectable and default option, update the documentation, and ensure the codebase respects these settings.