### PR TITLE
Inductive algorithm: shared breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The complementation and the inclusion checking might be adjusted by the followin
 | `tela` | `yes`,`no`  | If `yes`, use TELA-specific algorithms for complementation (if `no`, the input is converted to TBA) |
 | `sh-break` | `yes`,`no`  | Enable shared breakpoint across partial algorithms; when `yes` partial algorithms that support shared breakpoints propagate a common breakpoint across partitions |
 | `tela_det_alg` | `inductive`, `dnf-tela` | Algorithm selection for complementing deterministic TELA components (default `dnf-tela`) | 
+| `sd_ind_sh_break` | `yes`, `no` | Shared breakpoint for inductive TELA procedure (assumes `tela_det_alg=inductive`) |
 
 ## Testing
 

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -428,7 +428,7 @@ std::string check_macrostate::tree_type_to_string(TreeType t) {
   return "?";
 }
 
-std::string check_macrostate::to_string_impl(const base_tree& tree) {
+std::string check_macrostate::to_string_impl(const base_tree& tree, bool show_shared_breakpoint) {
   const std::string head = tree_type_to_string(tree.type());
   if (tree.is_leaf()) {
     const std::string payload = std::visit(
@@ -437,7 +437,12 @@ std::string check_macrostate::to_string_impl(const base_tree& tree) {
     return head + "(" + payload + ")";
   }
 
-  return head + "(" + to_string_impl(tree.left()) + ", " + to_string_impl(tree.right()) + ")";
+  std::string extra;
+  if (show_shared_breakpoint && (tree.type() == TreeType::And || tree.type() == TreeType::Or)) {
+    extra = "[sb=" + std::to_string(tree.node_value().shared_breakpoint) + "]";
+  }
+
+  return head + extra + "(" + to_string_impl(tree.left(), show_shared_breakpoint) + ", " + to_string_impl(tree.right(), show_shared_breakpoint) + ")";
 }
 
 /**

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -217,7 +217,7 @@ sd_inductive::check_macrostate restrict_states_in_tree(
   const std::set<unsigned>& forbidden) {
 
   using check_macrostate = sd_inductive::check_macrostate;
-  using base_tree = kofola::types::binary_tree<sd_inductive::TreeType, std::monostate, sd_inductive::fin_leaf, sd_inductive::inf_leaf>;
+  using base_tree = kofola::types::binary_tree<sd_inductive::TreeType, sd_inductive::AndOrNode, sd_inductive::fin_leaf, sd_inductive::inf_leaf>;
 
   if (tree.is_leaf()) {
     return std::visit(

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -217,7 +217,7 @@ sd_inductive::check_macrostate restrict_states_in_tree(
   const std::set<unsigned>& forbidden) {
 
   using check_macrostate = sd_inductive::check_macrostate;
-  using base_tree = kofola::types::binary_tree<sd_inductive::TreeType, sd_inductive::fin_leaf, sd_inductive::inf_leaf>;
+  using base_tree = kofola::types::binary_tree<sd_inductive::TreeType, std::monostate, sd_inductive::fin_leaf, sd_inductive::inf_leaf>;
 
   if (tree.is_leaf()) {
     return std::visit(

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -26,19 +26,19 @@ check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id
         using leaf_t = std::decay_t<decltype(leaf)>;
         const unsigned id = next_id++;
         if constexpr (std::is_same_v<leaf_t, fin_leaf>) {
-          return check_macrostate::fin(leaf.safe, leaf.color, id);
+          return check_macrostate::fin(tree.get_options_ptr(), leaf.safe, leaf.color, id);
         } else {
           static_assert(std::is_same_v<leaf_t, inf_leaf>, "Unexpected leaf type");
-          return check_macrostate::inf(leaf.track, leaf.breakpoint, leaf.color, id);
+          return check_macrostate::inf(tree.get_options_ptr(), leaf.track, leaf.breakpoint, leaf.color, id);
         }
       },
       tree.leaf_value());
   }
 
-  const check_macrostate left_ms(base_tree(tree.left()));
-  const check_macrostate right_ms(base_tree(tree.right()));
+  const check_macrostate left_ms(tree.get_options_ptr(), base_tree(tree.left()));
+  const check_macrostate right_ms(tree.get_options_ptr(), base_tree(tree.right()));
   const auto node_type = tree.type();
-  return check_macrostate::make(node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id));
+  return check_macrostate::make(tree.get_options_ptr(), node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id));
 }
 
 } // namespace
@@ -65,8 +65,8 @@ check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id
  * @throws std::invalid_argument if `code` is empty or contains an
  *         unsupported/top-level operator that cannot be represented.
  */
-check_macrostate check_macrostate::from_acc_code(const spot::acc_cond::acc_code& code) {
-  const auto parsed = from_acc_code_impl(code);
+check_macrostate check_macrostate::from_acc_code(options_ptr opts, const spot::acc_cond::acc_code& code) {
+  const auto parsed = from_acc_code_impl(std::move(opts), code);
   unsigned next_id = 0;
   return assign_leaf_ids(parsed, next_id);
 }
@@ -105,21 +105,21 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   if (this->is_leaf()) {
     return std::visit(
       [&](const auto& leaf) {
-        return leaf.get_succ(aut, scc_info, check_states, bdd, resample, parent_context);
+        return leaf.get_succ(aut, scc_info, check_states, this->opts_, bdd, resample, parent_context);
       },
       this->leaf_value());
   }
 
   // Propagate/merge context from parent into this node.
   NodeContext context = parent_context;
-  if (this->type() == TreeType::And || this->type() == TreeType::Or) {
+  if ((this->type() == TreeType::And || this->type() == TreeType::Or) && this->opts_->use_shared_breakpoint) {
     const NodeContext local = this->node_value().get_context();
     context = local.merge_contexts(parent_context);
   }
 
   const auto node_type = this->type();
-  const check_macrostate left_ms(base_tree(this->left()));
-  const check_macrostate right_ms(base_tree(this->right()));
+  const check_macrostate left_ms(this->opts_, base_tree(this->left()));
+  const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And) {
     const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
@@ -127,8 +127,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
     return cartesian_product<check_macrostate, check_macrostate>(
       left_succ,
       right_succ,
-      [](const check_macrostate& l, const check_macrostate& r) {
-        return check_macrostate::make(TreeType::And, l, r);
+      [opts = this->opts_](const check_macrostate& l, const check_macrostate& r) {
+        return check_macrostate::make(opts, TreeType::And, l, r);
       });
   }
 
@@ -148,8 +148,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       const auto combined = cartesian_product<check_macrostate, check_macrostate>(
         left_succ,
         right_succ,
-        [](const check_macrostate& l, const check_macrostate& r) {
-          return check_macrostate::make(TreeType::Or, l, r).reduce();
+        [opts = this->opts_](const check_macrostate& l, const check_macrostate& r) {
+          return check_macrostate::make(opts, TreeType::Or, l, r).reduce();
         });
       out.insert(combined.begin(), combined.end());
     }
@@ -180,8 +180,8 @@ bool check_macrostate::is_satisfied() const {
   }
 
   const auto node_type = this->type();
-  const check_macrostate left_ms(base_tree(this->left()));
-  const check_macrostate right_ms(base_tree(this->right()));
+  const check_macrostate left_ms(this->opts_, base_tree(this->left()));
+  const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And || node_type == TreeType::Or) {
     return left_ms.is_satisfied() && right_ms.is_satisfied();
@@ -225,8 +225,8 @@ std::set<unsigned> check_macrostate::gather_states() const {
     throw std::logic_error("check_macrostate::gather_states: unexpected internal node type");
   }
 
-  const check_macrostate left_ms(base_tree(this->left()));
-  const check_macrostate right_ms(base_tree(this->right()));
+  const check_macrostate left_ms(this->opts_, base_tree(this->left()));
+  const check_macrostate right_ms(this->opts_, base_tree(this->right()));
   return get_set_union(left_ms.gather_states(), right_ms.gather_states());
 }
 
@@ -262,10 +262,11 @@ sd_inductive::check_macrostate restrict_states_in_tree(
       [&](const auto& leaf) -> check_macrostate {
         using leaf_t = std::decay_t<decltype(leaf)>;
         if constexpr (std::is_same_v<leaf_t, sd_inductive::fin_leaf>) {
-          return check_macrostate::fin(get_set_difference(leaf.safe, forbidden), leaf.color, leaf.id);
+          return check_macrostate::fin(tree.get_options_ptr(), get_set_difference(leaf.safe, forbidden), leaf.color, leaf.id);
         } else {
           static_assert(std::is_same_v<leaf_t, sd_inductive::inf_leaf>, "Unexpected leaf type");
           return check_macrostate::inf(
+            tree.get_options_ptr(),
             get_set_difference(leaf.track, forbidden),
             get_set_difference(leaf.breakpoint, forbidden),
             leaf.color,
@@ -276,9 +277,10 @@ sd_inductive::check_macrostate restrict_states_in_tree(
   }
 
   const auto node_type = tree.type();
-  check_macrostate left(base_tree(tree.left()));
-  check_macrostate right(base_tree(tree.right()));
+  check_macrostate left(tree.get_options_ptr(), base_tree(tree.left()));
+  check_macrostate right(tree.get_options_ptr(), base_tree(tree.right()));
   return check_macrostate::make(
+    tree.get_options_ptr(),
     node_type,
     restrict_states_in_tree(left, forbidden),
     restrict_states_in_tree(right, forbidden));
@@ -314,18 +316,18 @@ check_macrostate check_macrostate::reduce() const {
   }
 
   const auto node_type = this->type();
-  const check_macrostate left_ms(base_tree(this->left()));
-  const check_macrostate right_ms(base_tree(this->right()));
+  const check_macrostate left_ms(this->opts_, base_tree(this->left()));
+  const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And) {
-    return check_macrostate::make(TreeType::And, left_ms.reduce(), right_ms.reduce());
+    return check_macrostate::make(this->opts_, TreeType::And, left_ms.reduce(), right_ms.reduce());
   }
 
   if (node_type == TreeType::Or) {
     const check_macrostate left_red = left_ms.reduce();
     const auto left_states = left_red.gather_states();
     const check_macrostate right_restricted = restrict_states_in_tree(right_ms, left_states);
-    return check_macrostate::make(TreeType::Or, left_red, right_restricted.reduce());
+    return check_macrostate::make(this->opts_, TreeType::Or, left_red, right_restricted.reduce());
   }
 
   throw std::logic_error("check_macrostate::reduce: unexpected internal node type");
@@ -346,13 +348,13 @@ check_macrostate check_macrostate::reduce() const {
  *         formula.
  * @throws std::invalid_argument if `parts` is empty.
  */
-check_macrostate check_macrostate::fold(TreeType op, const std::vector<spot::acc_cond::acc_code>& parts) {
+check_macrostate check_macrostate::fold(options_ptr opts, TreeType op, const std::vector<spot::acc_cond::acc_code>& parts) {
   if (parts.empty()) {
     throw std::invalid_argument("check_macrostate: empty And/Or in acceptance formula");
   }
-  check_macrostate acc = from_acc_code_impl(parts.front());
+  check_macrostate acc = from_acc_code_impl(opts, parts.front());
   for (size_t i = 1; i < parts.size(); ++i) {
-    acc = check_macrostate::make(op, std::move(acc), from_acc_code_impl(parts[i]));
+    acc = check_macrostate::make(opts, op, std::move(acc), from_acc_code_impl(opts, parts[i]));
   }
   return acc;
 }
@@ -371,7 +373,7 @@ check_macrostate check_macrostate::fold(TreeType op, const std::vector<spot::acc
  * @throws std::invalid_argument if `code` is empty or contains an
  *         unsupported acceptance operator.
  */
-check_macrostate check_macrostate::from_acc_code_impl(const spot::acc_cond::acc_code& code) {
+check_macrostate check_macrostate::from_acc_code_impl(options_ptr opts, const spot::acc_cond::acc_code& code) {
   if (code.empty()) {
     throw std::invalid_argument("check_macrostate: empty acceptance formula");
   }
@@ -381,31 +383,31 @@ check_macrostate check_macrostate::from_acc_code_impl(const spot::acc_cond::acc_
     const auto op = code[1].sub.op;
     const auto mark = code[0].mark;
     if (op == spot::acc_cond::acc_op::Fin) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
+      return check_macrostate(opts, base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
     }
     if (op == spot::acc_cond::acc_op::Inf) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
+      return check_macrostate(opts, base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
     }
   }
 
   // Prefer top-level flattening (Spot returns a singleton vector when the operator is not present at top-level).
   const auto conjuncts = code.top_conjuncts();
   if (conjuncts.size() > 1) {
-    return fold(TreeType::And, conjuncts);
+    return fold(opts, TreeType::And, conjuncts);
   }
   const auto disjuncts = code.top_disjuncts();
   if (disjuncts.size() > 1) {
-    return fold(TreeType::Or, disjuncts);
+    return fold(opts, TreeType::Or, disjuncts);
   }
 
   if (code.size() == 2) {
     const auto op = code[1].sub.op;
     const auto mark = code[0].mark;
     if (op == spot::acc_cond::acc_op::Fin) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
+      return check_macrostate(opts, base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
     }
     if (op == spot::acc_cond::acc_op::Inf) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
+      return check_macrostate(opts, base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
     }
   }
 
@@ -464,10 +466,12 @@ std::vector<check_macrostate> fin_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
+  options_ptr                        opts,
   const bdd&                        bdd,
   bool                              resample,
   const NodeContext&                context) const {
 
+  (void)opts;
   (void)resample; // unused
   (void)context;  // unused
   std::set<unsigned> st = get_set_union(this->safe, check_states);
@@ -482,7 +486,7 @@ std::vector<check_macrostate> fin_leaf::get_succ(
       }
     }
   }
-  return {check_macrostate::fin(std::move(succs), this->color, this->id)};
+  return {check_macrostate::fin(std::move(opts), std::move(succs), this->color, this->id)};
 }
 
 bool fin_leaf::is_satisfied() const {
@@ -519,6 +523,7 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
+  options_ptr                        opts,
   const bdd&                        bdd,
   bool                              resample,
   const NodeContext&                context) const {
@@ -536,7 +541,8 @@ std::vector<check_macrostate> inf_leaf::get_succ(
 
   if (!resample) {
     const std::set<unsigned>* breakpoint_src = &this->breakpoint;
-    if (context.type == NodeContextType::SHARED_BREAKPOINT &&
+    if (opts && opts->use_shared_breakpoint &&
+        context.type == NodeContextType::SHARED_BREAKPOINT &&
         context.breakpoint.has_value() &&
         context.leaf_id == this->id) {
       breakpoint_src = &context.breakpoint->get();
@@ -554,16 +560,17 @@ std::vector<check_macrostate> inf_leaf::get_succ(
     }
 
     // If using a shared breakpoint context, update it in-place.
-    if (context.type == NodeContextType::SHARED_BREAKPOINT &&
+    if (opts && opts->use_shared_breakpoint &&
+        context.type == NodeContextType::SHARED_BREAKPOINT &&
         context.breakpoint.has_value() &&
         context.leaf_id == this->id) {
       context.breakpoint->get() = succ_break;
     }
-    return {check_macrostate::inf(std::move(succs), std::move(succ_break), this->color, this->id)};
+    return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
   }
 
   auto succs_copy = succs;
-  return {check_macrostate::inf(std::move(succs), std::move(succs_copy), this->color, this->id)};
+  return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succs_copy), this->color, this->id)};
 }
 
 bool inf_leaf::is_satisfied() const {
@@ -626,6 +633,9 @@ complement_sd_inductive::complement_sd_inductive(const cmpl_info& info, unsigned
   
   spot::acc_cond::acc_code acc = this->info_.part_to_acc_map_.at(part_index_).get_acceptance();
   this->acc_cond_ = acc.complement();
+  this->opts_ = std::make_shared<sd_inductive::options>(sd_inductive::options{
+    .use_shared_breakpoint = (kofola::OPTIONS.params["sd_ind_sh_break"] == "yes")
+  });
 }
 
 /**
@@ -648,7 +658,10 @@ mstate_set complement_sd_inductive::get_init() { // {{
     init_state.insert(orig_init);
   }
 
-  std::shared_ptr<mstate> ms(new sd_inductive::mstate_sd_inductive(init_state, sd_inductive::check_macrostate::from_acc_code(this->acc_cond_), sd_inductive::mstate_type::GUESS));
+  std::shared_ptr<mstate> ms(new sd_inductive::mstate_sd_inductive(
+    init_state,
+    sd_inductive::check_macrostate::from_acc_code(this->opts_, this->acc_cond_),
+    sd_inductive::mstate_type::GUESS));
   mstate_set result = {ms};
   return result;
 } // get_init() }}}

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -41,6 +41,41 @@ check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id
   return check_macrostate::make(tree.get_options_ptr(), node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id), tree.node_value().context);
 }
 
+/**
+ * @brief Initialize (or re-initialize) `NodeContext` payloads inside a check tree.
+ *
+ * When shared-breakpoint mode is enabled (`opts->use_shared_breakpoint == true`),
+ * each internal node's `NodeContext` is recomputed from the subtree so that it
+ * references the current set of `Inf` leaf IDs.
+ *
+ * @param tree Check tree to update in-place.
+ * @param opts Options controlling whether shared-breakpoint contexts are used.
+ *             Must be non-null.
+ *
+ * @warning This function traverses children by casting `base_tree::left()/right()`
+ *          to `check_macrostate&`. The underlying tree stores children as
+ *          `base_tree`, not `check_macrostate`, so these casts are undefined
+ *          behavior and can manifest as crashes (e.g., seemingly-null
+ *          `get_options_ptr()`). Prefer a functional rebuild that wraps children
+ *          as `check_macrostate(opts, base_tree(child))` if you need a safe
+ *          traversal.
+ */
+void init_contexts_in_tree(check_macrostate& tree, options_ptr opts) {
+  if (tree.is_leaf()) {
+    return;
+  }
+
+  auto& base = static_cast<base_tree&>(tree);
+  init_contexts_in_tree(static_cast<check_macrostate&>(base.left()), opts);
+  init_contexts_in_tree(static_cast<check_macrostate&>(base.right()), opts);
+
+  if (opts->use_shared_breakpoint) {
+    NodeContext ctx = NodeContext::create_subtree_sh_context(tree.type(), tree);
+    tree.node_value().set_context(ctx);
+  }
+  
+}
+
 } // namespace
 
 /**
@@ -68,7 +103,28 @@ check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id
 check_macrostate check_macrostate::from_acc_code(options_ptr opts, const spot::acc_cond::acc_code& code) {
   const auto parsed = from_acc_code_impl(std::move(opts), code);
   unsigned next_id = 0;
-  return assign_leaf_ids(parsed, next_id);
+  // First assign stable leaf IDs, then (re)initialize NodeContext using the
+  // fully ID-annotated subtrees.
+  return assign_leaf_ids(parsed, next_id).init_contexts();
+}
+
+/**
+ * @brief Return a copy of this check tree with refreshed `NodeContext` values.
+ *
+ * Intended usage is after parsing acceptance and assigning stable leaf IDs.
+ * In shared-breakpoint mode, `NodeContext` depends on `inf_leaf::id`, so any
+ * transformation that changes leaf IDs should be followed by `init_contexts()`.
+ *
+ * @note The current implementation delegates to `init_contexts_in_tree()`,
+ *       which performs an in-place traversal using casts that assume children
+ *       are `check_macrostate`. If you observe intermittent crashes here,
+ *       refactor to a traversal that rebuilds the tree while wrapping children
+ *       with `check_macrostate(opts, base_tree(child))`. 
+ */
+check_macrostate check_macrostate::init_contexts() const {
+  check_macrostate out = *this;
+  init_contexts_in_tree(out, this->opts_);
+  return out;
 }
 
 /**
@@ -112,15 +168,11 @@ std::vector<check_macrostate> check_macrostate::get_succ(
 
   // Propagate/merge context from parent into this node.
   // NodeContext& context = parent_context;
-  NodeContext local = this->node_value().get_context();
-  NodeContext& context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
-  // if ((this->type() == TreeType::And || this->type() == TreeType::Or) && this->opts_->use_shared_breakpoint) {
-  //   // std::cout << "merging " << int(local.type) << ": " << (this->type() == TreeType::And) << " with " << int(parent_context.type) << std::endl;
-  //   // std::cout << this->to_string() << std::endl;
 
-  //   std::cout << local << " ::: " << parent_context << " ::: " << context << std::endl;
-  //   // context = local.merge_contexts(parent_context);
-  // }
+  // TODO: add comment how it is working
+  NodeContext actual_ctx = this->node_value().get_context();
+  NodeContext local = !actual_ctx.is_mergable(parent_context) ? this->node_value().get_succ_context(resample) : actual_ctx;
+  NodeContext& context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
 
   const auto node_type = this->type();
   const check_macrostate left_ms(this->opts_, base_tree(this->left()));
@@ -129,13 +181,12 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   if (node_type == TreeType::And) {
     const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
     const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
-    
+
     return cartesian_product<check_macrostate, check_macrostate>(
       left_succ,
       right_succ,
       [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
-        auto tmp = check_macrostate::make(opts, TreeType::And, l, r);
-        tmp.node_value().set_context(local);
+        auto tmp = check_macrostate::make(opts, TreeType::And, l, r, local);
         return tmp;
       });
   }
@@ -157,8 +208,7 @@ std::vector<check_macrostate> check_macrostate::get_succ(
         left_succ,
         right_succ,
         [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
-          auto tmp = check_macrostate::make(opts, TreeType::Or, l, r);
-          tmp.node_value().set_context(local);
+          auto tmp = check_macrostate::make(opts, TreeType::Or, l, r, local);
           return tmp.reduce();
         });
       out.insert(combined.begin(), combined.end());
@@ -555,6 +605,45 @@ std::vector<check_macrostate> inf_leaf::get_succ(
         succs.insert(t.dst);
       }
     }
+  }
+
+  if(opts && opts->use_shared_breakpoint && context.type == NodeContextType::SHARED_BREAKPOINT) {
+
+    if(context.leaf_id != this->id) {
+      return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+    }
+
+    assert(!resample || context.state == NodeContextState::RESAMLE_LEAF);
+    
+
+    if(context.state == NodeContextState::GLOBAL_WAIT) {
+      return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+    } else if(context.state == NodeContextState::RESAMLE_LEAF) {
+      succ_break = succs;
+      if(context.leaf_id == this->id) {
+        //std::cout << "context finished reset for leaf " << this->id << std::endl;
+        context.state = NodeContextState::PROCESS_LEAF;
+      }
+    } else {
+      for (unsigned s : context.breakpoint) {
+        for (const auto& t : aut->out(s)) {
+          if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
+            if (t.acc & this->color) {
+              continue;
+            }
+            succ_break.insert(t.dst);
+          }
+        }
+      }
+    }
+
+    if(context.leaf_id == this->id) {
+      // If using a shared breakpoint context, update it in-place.
+      context.breakpoint = succ_break;
+      succ_break.clear();
+    } 
+    
+    return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
   }
 
   if (!resample) {

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -166,12 +166,12 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       this->leaf_value());
   }
 
-  // Propagate/merge context from parent into this node.
-  // NodeContext& context = parent_context;
-
-  // TODO: add comment how it is working
+  // we get current context (for nodes not using meanungful contexts it is unique default context)
   NodeContext actual_ctx = this->node_value().get_context();
+  // if parent context is not mergable with the parent == it is a root of a subtree where shared breakpoint is used
   NodeContext local = !actual_ctx.is_mergable(parent_context) ? this->node_value().get_succ_context(resample) : actual_ctx;
+  // we either take predecessor reference of reference to local; get_succ applied on leaves modifies 
+  // the context reference 
   NodeContext& context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
 
   const auto node_type = this->type();
@@ -597,31 +597,19 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   NodeContext&                      context) const {
 
   std::set<unsigned> st = get_set_union(this->track, check_states);
-  std::set<unsigned> succs {};
+  std::set<unsigned> succs = kofola::get_all_successors_in_scc(aut, scc_info, st, bdd);
   std::set<unsigned> succ_break {};
-  for (unsigned s : st) {
-    for (const auto& t : aut->out(s)) {
-      if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
-        succs.insert(t.dst);
-      }
-    }
-  }
 
   if(opts && opts->use_shared_breakpoint && context.type == NodeContextType::SHARED_BREAKPOINT) {
-
     if(context.leaf_id != this->id) {
       return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
     }
-
     assert(!resample || context.state == NodeContextState::RESAMLE_LEAF);
-    
-
     if(context.state == NodeContextState::GLOBAL_WAIT) {
       return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
     } else if(context.state == NodeContextState::RESAMLE_LEAF) {
       succ_break = succs;
       if(context.leaf_id == this->id) {
-        //std::cout << "context finished reset for leaf " << this->id << std::endl;
         context.state = NodeContextState::PROCESS_LEAF;
       }
     } else {
@@ -647,14 +635,7 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   }
 
   if (!resample) {
-    const std::set<unsigned>* breakpoint_src = &this->breakpoint;
-    if (opts && opts->use_shared_breakpoint &&
-        context.type == NodeContextType::SHARED_BREAKPOINT &&
-        context.leaf_id == this->id) {
-      breakpoint_src = &context.breakpoint;
-    }
-
-    for (unsigned s : *breakpoint_src) {
+    for (unsigned s : this->breakpoint) {
       for (const auto& t : aut->out(s)) {
         if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
           if (t.acc & this->color) {
@@ -665,26 +646,10 @@ std::vector<check_macrostate> inf_leaf::get_succ(
       }
     }
 
-    // If using a shared breakpoint context, update it in-place.
-    if (opts && opts->use_shared_breakpoint &&
-        context.type == NodeContextType::SHARED_BREAKPOINT &&
-        context.leaf_id == this->id) {
-      context.breakpoint = succ_break;
-      succ_break.clear();
-    }
     return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
   }
 
   auto succs_copy = succs;
-
-  if (opts && opts->use_shared_breakpoint &&
-    context.type == NodeContextType::SHARED_BREAKPOINT &&
-    context.leaf_id == this->id) {
-
-    context.breakpoint = succs_copy;
-    succs_copy.clear();
-  }
-
   return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succs_copy), this->color, this->id)};
 }
 

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -38,7 +38,7 @@ check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id
   const check_macrostate left_ms(tree.get_options_ptr(), base_tree(tree.left()));
   const check_macrostate right_ms(tree.get_options_ptr(), base_tree(tree.right()));
   const auto node_type = tree.type();
-  return check_macrostate::make(tree.get_options_ptr(), node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id));
+  return check_macrostate::make(tree.get_options_ptr(), node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id), tree.node_value().context);
 }
 
 } // namespace
@@ -100,7 +100,7 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   const std::set<unsigned>&         check_states,
   const bdd&                        bdd,
   bool                              resample,
-  const NodeContext&                parent_context) const {
+  NodeContext&                      parent_context) const {
 
   if (this->is_leaf()) {
     return std::visit(
@@ -111,11 +111,16 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   }
 
   // Propagate/merge context from parent into this node.
-  NodeContext context = parent_context;
-  if ((this->type() == TreeType::And || this->type() == TreeType::Or) && this->opts_->use_shared_breakpoint) {
-    const NodeContext local = this->node_value().get_context();
-    context = local.merge_contexts(parent_context);
-  }
+  // NodeContext& context = parent_context;
+  NodeContext local = this->node_value().get_context();
+  NodeContext& context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
+  // if ((this->type() == TreeType::And || this->type() == TreeType::Or) && this->opts_->use_shared_breakpoint) {
+  //   // std::cout << "merging " << int(local.type) << ": " << (this->type() == TreeType::And) << " with " << int(parent_context.type) << std::endl;
+  //   // std::cout << this->to_string() << std::endl;
+
+  //   std::cout << local << " ::: " << parent_context << " ::: " << context << std::endl;
+  //   // context = local.merge_contexts(parent_context);
+  // }
 
   const auto node_type = this->type();
   const check_macrostate left_ms(this->opts_, base_tree(this->left()));
@@ -124,11 +129,14 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   if (node_type == TreeType::And) {
     const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
     const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
+    
     return cartesian_product<check_macrostate, check_macrostate>(
       left_succ,
       right_succ,
-      [opts = this->opts_](const check_macrostate& l, const check_macrostate& r) {
-        return check_macrostate::make(opts, TreeType::And, l, r);
+      [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
+        auto tmp = check_macrostate::make(opts, TreeType::And, l, r);
+        tmp.node_value().set_context(local);
+        return tmp;
       });
   }
 
@@ -148,8 +156,10 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       const auto combined = cartesian_product<check_macrostate, check_macrostate>(
         left_succ,
         right_succ,
-        [opts = this->opts_](const check_macrostate& l, const check_macrostate& r) {
-          return check_macrostate::make(opts, TreeType::Or, l, r).reduce();
+        [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
+          auto tmp = check_macrostate::make(opts, TreeType::Or, l, r);
+          tmp.node_value().set_context(local);
+          return tmp.reduce();
         });
       out.insert(combined.begin(), combined.end());
     }
@@ -184,7 +194,7 @@ bool check_macrostate::is_satisfied() const {
   const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And || node_type == TreeType::Or) {
-    return left_ms.is_satisfied() && right_ms.is_satisfied();
+    return this->node_value().is_satisfied() && left_ms.is_satisfied() && right_ms.is_satisfied();
   }
 
   throw std::logic_error("check_macrostate::is_satisfied: unexpected internal node type");
@@ -279,11 +289,14 @@ sd_inductive::check_macrostate restrict_states_in_tree(
   const auto node_type = tree.type();
   check_macrostate left(tree.get_options_ptr(), base_tree(tree.left()));
   check_macrostate right(tree.get_options_ptr(), base_tree(tree.right()));
+  NodeContext context = tree.node_value().context;
+  context.restrict_states(forbidden);
   return check_macrostate::make(
     tree.get_options_ptr(),
     node_type,
     restrict_states_in_tree(left, forbidden),
-    restrict_states_in_tree(right, forbidden));
+    restrict_states_in_tree(right, forbidden),
+    context);
 }
 
 } // namespace
@@ -320,14 +333,14 @@ check_macrostate check_macrostate::reduce() const {
   const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And) {
-    return check_macrostate::make(this->opts_, TreeType::And, left_ms.reduce(), right_ms.reduce());
+    return check_macrostate::make(this->opts_, TreeType::And, left_ms.reduce(), right_ms.reduce(), this->node_value().context);
   }
 
   if (node_type == TreeType::Or) {
     const check_macrostate left_red = left_ms.reduce();
     const auto left_states = left_red.gather_states();
     const check_macrostate right_restricted = restrict_states_in_tree(right_ms, left_states);
-    return check_macrostate::make(this->opts_, TreeType::Or, left_red, right_restricted.reduce());
+    return check_macrostate::make(this->opts_, TreeType::Or, left_red, right_restricted.reduce(), this->node_value().context);
   }
 
   throw std::logic_error("check_macrostate::reduce: unexpected internal node type");
@@ -439,7 +452,7 @@ std::string check_macrostate::to_string_impl(const base_tree& tree, bool show_sh
 
   std::string extra;
   if (show_shared_breakpoint && (tree.type() == TreeType::And || tree.type() == TreeType::Or)) {
-    extra = "[sb=" + std::to_string(tree.node_value().shared_breakpoint) + "]";
+    extra = "[sb=" + tree.node_value().context.to_string() + "]";
   }
 
   return head + extra + "(" + to_string_impl(tree.left(), show_shared_breakpoint) + ", " + to_string_impl(tree.right(), show_shared_breakpoint) + ")";
@@ -474,7 +487,7 @@ std::vector<check_macrostate> fin_leaf::get_succ(
   options_ptr                        opts,
   const bdd&                        bdd,
   bool                              resample,
-  const NodeContext&                context) const {
+  NodeContext&                      context) const {
 
   (void)opts;
   (void)resample; // unused
@@ -528,10 +541,10 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
-  options_ptr                        opts,
+  options_ptr                       opts,
   const bdd&                        bdd,
   bool                              resample,
-  const NodeContext&                context) const {
+  NodeContext&                      context) const {
 
   std::set<unsigned> st = get_set_union(this->track, check_states);
   std::set<unsigned> succs {};
@@ -548,9 +561,8 @@ std::vector<check_macrostate> inf_leaf::get_succ(
     const std::set<unsigned>* breakpoint_src = &this->breakpoint;
     if (opts && opts->use_shared_breakpoint &&
         context.type == NodeContextType::SHARED_BREAKPOINT &&
-        context.breakpoint.has_value() &&
         context.leaf_id == this->id) {
-      breakpoint_src = &context.breakpoint->get();
+      breakpoint_src = &context.breakpoint;
     }
 
     for (unsigned s : *breakpoint_src) {
@@ -567,14 +579,23 @@ std::vector<check_macrostate> inf_leaf::get_succ(
     // If using a shared breakpoint context, update it in-place.
     if (opts && opts->use_shared_breakpoint &&
         context.type == NodeContextType::SHARED_BREAKPOINT &&
-        context.breakpoint.has_value() &&
         context.leaf_id == this->id) {
-      context.breakpoint->get() = succ_break;
+      context.breakpoint = succ_break;
+      succ_break.clear();
     }
     return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
   }
 
   auto succs_copy = succs;
+
+  if (opts && opts->use_shared_breakpoint &&
+    context.type == NodeContextType::SHARED_BREAKPOINT &&
+    context.leaf_id == this->id) {
+
+    context.breakpoint = succs_copy;
+    succs_copy.clear();
+  }
+
   return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succs_copy), this->color, this->id)};
 }
 
@@ -712,14 +733,16 @@ mstate_col_set complement_sd_inductive::get_succ_active(
 
   mstate_col_set result {};
   std::set<unsigned> empty{};
+  sd_inductive::NodeContext context{};
 
   std::set<unsigned> succ_check = kofola::get_all_successors_in_scc(
       this->info_.aut_, this->info_.scc_info_, src_mst->check_, symbol);
   std::vector<sd_inductive::check_macrostate> succ_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
-      this->info_.scc_info_, empty, symbol, false);
+      this->info_.scc_info_, empty, symbol, false, context);
+
   if(src_mst->type_ == sd_inductive::mstate_type::GUESS) {
     std::vector<sd_inductive::check_macrostate> succ_check_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
-      this->info_.scc_info_, src_mst->check_, symbol, true);
+      this->info_.scc_info_, src_mst->check_, symbol, true, context);
     for(const auto& tree : succ_trees) {
       std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
           succ_check, tree, sd_inductive::mstate_type::GUESS));

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -15,6 +15,34 @@ using mstate_col_set = abstract_complement_alg::mstate_col_set;
 namespace kofola {
 namespace sd_inductive {
 
+namespace {
+
+using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
+
+check_macrostate assign_leaf_ids(const check_macrostate& tree, unsigned& next_id) {
+  if (tree.is_leaf()) {
+    return std::visit(
+      [&](const auto& leaf) -> check_macrostate {
+        using leaf_t = std::decay_t<decltype(leaf)>;
+        const unsigned id = next_id++;
+        if constexpr (std::is_same_v<leaf_t, fin_leaf>) {
+          return check_macrostate::fin(leaf.safe, leaf.color, id);
+        } else {
+          static_assert(std::is_same_v<leaf_t, inf_leaf>, "Unexpected leaf type");
+          return check_macrostate::inf(leaf.track, leaf.breakpoint, leaf.color, id);
+        }
+      },
+      tree.leaf_value());
+  }
+
+  const check_macrostate left_ms(base_tree(tree.left()));
+  const check_macrostate right_ms(base_tree(tree.right()));
+  const auto node_type = tree.type();
+  return check_macrostate::make(node_type, assign_leaf_ids(left_ms, next_id), assign_leaf_ids(right_ms, next_id));
+}
+
+} // namespace
+
 /**
  * Parse a Spot acceptance condition and build an equivalent
  * `check_macrostate` tree.
@@ -38,7 +66,9 @@ namespace sd_inductive {
  *         unsupported/top-level operator that cannot be represented.
  */
 check_macrostate check_macrostate::from_acc_code(const spot::acc_cond::acc_code& code) {
-  return from_acc_code_impl(code);
+  const auto parsed = from_acc_code_impl(code);
+  unsigned next_id = 0;
+  return assign_leaf_ids(parsed, next_id);
 }
 
 /**
@@ -69,14 +99,22 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   const bdd&                        bdd,
-  bool                              resample) const {
+  bool                              resample,
+  const NodeContext&                parent_context) const {
 
   if (this->is_leaf()) {
     return std::visit(
       [&](const auto& leaf) {
-        return leaf.get_succ(aut, scc_info, check_states, bdd, resample);
+        return leaf.get_succ(aut, scc_info, check_states, bdd, resample, parent_context);
       },
       this->leaf_value());
+  }
+
+  // Propagate/merge context from parent into this node.
+  NodeContext context = parent_context;
+  if (this->type() == TreeType::And || this->type() == TreeType::Or) {
+    const NodeContext local = this->node_value().get_context();
+    context = local.merge_contexts(parent_context);
   }
 
   const auto node_type = this->type();
@@ -84,8 +122,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   const check_macrostate right_ms(base_tree(this->right()));
 
   if (node_type == TreeType::And) {
-    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample);
-    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample);
+    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
+    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
     return cartesian_product<check_macrostate, check_macrostate>(
       left_succ,
       right_succ,
@@ -103,8 +141,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       }
       const auto& left_states = part[0];
       const auto& right_states = part[1];
-      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd, resample);
-      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample);
+      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd, resample, context);
+      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample, context);
 
       // TODO: it is not efficient to call reduce here
       const auto combined = cartesian_product<check_macrostate, check_macrostate>(
@@ -224,13 +262,14 @@ sd_inductive::check_macrostate restrict_states_in_tree(
       [&](const auto& leaf) -> check_macrostate {
         using leaf_t = std::decay_t<decltype(leaf)>;
         if constexpr (std::is_same_v<leaf_t, sd_inductive::fin_leaf>) {
-          return check_macrostate::fin(get_set_difference(leaf.safe, forbidden), leaf.color);
+          return check_macrostate::fin(get_set_difference(leaf.safe, forbidden), leaf.color, leaf.id);
         } else {
           static_assert(std::is_same_v<leaf_t, sd_inductive::inf_leaf>, "Unexpected leaf type");
           return check_macrostate::inf(
             get_set_difference(leaf.track, forbidden),
             get_set_difference(leaf.breakpoint, forbidden),
-            leaf.color);
+            leaf.color,
+            leaf.id);
         }
       },
       tree.leaf_value());
@@ -342,10 +381,10 @@ check_macrostate check_macrostate::from_acc_code_impl(const spot::acc_cond::acc_
     const auto op = code[1].sub.op;
     const auto mark = code[0].mark;
     if (op == spot::acc_cond::acc_op::Fin) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark}));
+      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
     }
     if (op == spot::acc_cond::acc_op::Inf) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark}));
+      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
     }
   }
 
@@ -363,10 +402,10 @@ check_macrostate check_macrostate::from_acc_code_impl(const spot::acc_cond::acc_
     const auto op = code[1].sub.op;
     const auto mark = code[0].mark;
     if (op == spot::acc_cond::acc_op::Fin) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark}));
+      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, mark, 0}));
     }
     if (op == spot::acc_cond::acc_op::Inf) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark}));
+      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, mark, 0}));
     }
   }
 
@@ -426,9 +465,11 @@ std::vector<check_macrostate> fin_leaf::get_succ(
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   const bdd&                        bdd,
-  bool                              resample) const {
+  bool                              resample,
+  const NodeContext&                context) const {
 
   (void)resample; // unused
+  (void)context;  // unused
   std::set<unsigned> st = get_set_union(this->safe, check_states);
   std::set<unsigned> succs {};
   for (unsigned s : st) {
@@ -441,7 +482,7 @@ std::vector<check_macrostate> fin_leaf::get_succ(
       }
     }
   }
-  return {check_macrostate::fin(std::move(succs), this->color)};
+  return {check_macrostate::fin(std::move(succs), this->color, this->id)};
 }
 
 bool fin_leaf::is_satisfied() const {
@@ -479,7 +520,8 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   const bdd&                        bdd,
-  bool                              resample) const {
+  bool                              resample,
+  const NodeContext&                context) const {
 
   std::set<unsigned> st = get_set_union(this->track, check_states);
   std::set<unsigned> succs {};
@@ -493,7 +535,14 @@ std::vector<check_macrostate> inf_leaf::get_succ(
   }
 
   if (!resample) {
-    for (unsigned s : this->breakpoint) {
+    const std::set<unsigned>* breakpoint_src = &this->breakpoint;
+    if (context.type == NodeContextType::SHARED_BREAKPOINT &&
+        context.breakpoint.has_value() &&
+        context.leaf_id == this->id) {
+      breakpoint_src = &context.breakpoint->get();
+    }
+
+    for (unsigned s : *breakpoint_src) {
       for (const auto& t : aut->out(s)) {
         if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
           if (t.acc & this->color) {
@@ -503,11 +552,18 @@ std::vector<check_macrostate> inf_leaf::get_succ(
         }
       }
     }
-    return {check_macrostate::inf(std::move(succs), std::move(succ_break), this->color)};
+
+    // If using a shared breakpoint context, update it in-place.
+    if (context.type == NodeContextType::SHARED_BREAKPOINT &&
+        context.breakpoint.has_value() &&
+        context.leaf_id == this->id) {
+      context.breakpoint->get() = succ_break;
+    }
+    return {check_macrostate::inf(std::move(succs), std::move(succ_break), this->color, this->id)};
   }
 
   auto succs_copy = succs;
-  return {check_macrostate::inf(std::move(succs), std::move(succs_copy), this->color)};
+  return {check_macrostate::inf(std::move(succs), std::move(succs_copy), this->color, this->id)};
 }
 
 bool inf_leaf::is_satisfied() const {

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -5,6 +5,7 @@
 #include "abstract_complement_alg.hpp"
 
 #include <compare>
+#include <memory>
 #include <ostream>
 #include <sstream>
 #include <set>
@@ -35,6 +36,24 @@ namespace sd_inductive {
   };
 
   class check_macrostate;
+
+  /**
+   * @brief Payload of an internal `And`/`Or` node in `check_macrostate`.
+   *
+   * Stores a subtree (rooted at the corresponding internal node) as a
+   * `check_macrostate`. This is stored indirectly to avoid recursive
+   * by-value type definitions.
+   */
+  struct AndOrNode {
+    TreeType type {TreeType::And};
+    std::shared_ptr<check_macrostate> subtree {};
+
+    AndOrNode() = default;
+    AndOrNode(TreeType t, check_macrostate subtree_);
+
+    bool operator==(const AndOrNode& other) const;
+    std::strong_ordering operator<=>(const AndOrNode& other) const;
+  };
 
   /**
    * @brief Payload of a `Fin` leaf in `check_macrostate`.
@@ -176,11 +195,12 @@ namespace sd_inductive {
    *
    * This is a thin wrapper over `kofola::types::binary_tree` with:
    * - node type: `TreeType`
+   * - internal-node payload: `AndOrNode`
    * - leaf payload: `fin_leaf` or `inf_leaf`
    */
-  class check_macrostate : public kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf> {
+  class check_macrostate : public kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf> {
     /** @brief Base tree type used for representation. */
-    using base_tree = kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf>;
+    using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
 
   public:
     /** @brief Deleted default constructor (a check must be a leaf or a node). */
@@ -253,9 +273,13 @@ namespace sd_inductive {
      * @return A `check_macrostate` internal node.
      */
     static check_macrostate make(TreeType type, check_macrostate left, check_macrostate right) {
+      // Build a concrete subtree rooted at this internal node.
+      // We intentionally construct this subtree using a default internal
+      // payload, and store it in the node payload for now.
+      check_macrostate subtree_root(base_tree::make_node(type, base_tree(left), base_tree(right)));
       base_tree l(std::move(left));
       base_tree r(std::move(right));
-      return check_macrostate(base_tree::make_node(type, std::move(l), std::move(r)));
+      return check_macrostate(base_tree::make_node(type, AndOrNode(type, std::move(subtree_root)), std::move(l), std::move(r)));
     }
 
     /**
@@ -329,6 +353,50 @@ namespace sd_inductive {
      */
     static std::string to_string_impl(const base_tree& tree);
   };
+
+  inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_)
+    : type(t),
+      subtree(std::make_shared<check_macrostate>(std::move(subtree_))) {}
+
+  inline bool AndOrNode::operator==(const AndOrNode& other) const {
+    if (this->type != other.type) {
+      return false;
+    }
+    if (!this->subtree && !other.subtree) {
+      return true;
+    }
+    if (!this->subtree || !other.subtree) {
+      return false;
+    }
+    return *this->subtree == *other.subtree;
+  }
+
+  inline std::strong_ordering AndOrNode::operator<=>(const AndOrNode& other) const {
+    if (this->type < other.type) {
+      return std::strong_ordering::less;
+    }
+    if (other.type < this->type) {
+      return std::strong_ordering::greater;
+    }
+
+    // Same type: order by subtree presence then subtree structure.
+    if (!this->subtree && !other.subtree) {
+      return std::strong_ordering::equal;
+    }
+    if (!this->subtree) {
+      return std::strong_ordering::less;
+    }
+    if (!other.subtree) {
+      return std::strong_ordering::greater;
+    }
+    if (*this->subtree < *other.subtree) {
+      return std::strong_ordering::less;
+    }
+    if (*other.subtree < *this->subtree) {
+      return std::strong_ordering::greater;
+    }
+    return std::strong_ordering::equal;
+  }
 
 enum class mstate_type {
   GUESS,

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -48,7 +48,15 @@ namespace sd_inductive {
     SHARED_BREAKPOINT
   };
 
+  enum class NodeContextState {
+    GLOBAL_WAIT,
+    RESAMLE_LEAF,
+    PROCESS_LEAF,
+  };
+
   class check_macrostate;
+
+  inline void collect_inf_leaf_ids(const check_macrostate& t, std::vector<unsigned>& out);
 
   struct NodeContext;
   std::ostream& operator<<(std::ostream& os, const NodeContext& ctx);
@@ -60,7 +68,124 @@ namespace sd_inductive {
     unsigned leaf_id {0};
     unsigned leaf_index {0};
     std::vector<unsigned> leaf_ids {};
+    NodeContextState state {NodeContextState::GLOBAL_WAIT};
 
+    /**
+     * @brief Compute the successor context for one transition step.
+     *
+     * This method implements the small state machine used by the
+     * shared-breakpoint optimization.
+     *
+     * - If `type != SHARED_BREAKPOINT`, the context is returned unchanged.
+     * - In `GLOBAL_WAIT`, a `resample` request moves the context to
+     *   `RESAMLE_LEAF` (otherwise it stays in `GLOBAL_WAIT`).
+     * - In `PROCESS_LEAF`, the selected leaf is advanced when the breakpoint
+     *   becomes empty; when the leaf index wraps to 0, the state returns to
+     *   `GLOBAL_WAIT`.
+     *
+     * @param resample Whether the caller requests a resampling step.
+     * @return A copy of this context updated for the next step.
+     */
+    NodeContext get_succ_context(bool resample) const {
+      NodeContext succ = *this;
+      if(this->type != NodeContextType::SHARED_BREAKPOINT) {
+        return succ;
+      }
+
+      if(this->state == NodeContextState::GLOBAL_WAIT) {
+        if(resample) {
+          succ.state = NodeContextState::RESAMLE_LEAF;
+        }
+        // else do nothing
+      } else if(this->state == NodeContextState::RESAMLE_LEAF) {
+        assert(false);
+        return succ;
+      } else {
+        if(succ.leaf_ids.size() > 0) {
+          succ.leaf_index = succ.leaf_index % succ.leaf_ids.size();
+          if(succ.breakpoint.empty()) {
+            succ.leaf_index = (succ.leaf_index + 1) % succ.leaf_ids.size();
+            if(succ.leaf_index == 0) {
+              succ.state = NodeContextState::GLOBAL_WAIT;
+            } else {
+              succ.state = NodeContextState::RESAMLE_LEAF;
+            }
+          }
+        }
+        succ.leaf_id = succ.leaf_ids[succ.leaf_index];
+      }
+      
+      return succ;
+    }
+
+    /**
+     * @brief Build a shared-breakpoint context for a subtree.
+     *
+     * Collects all `Inf` leaf IDs from @p subtree_ and, if the subtree root
+     * is an `And` node with at least one `Inf` leaf, initializes the returned
+     * context as `SHARED_BREAKPOINT` and selects the first leaf ID.
+     *
+     * @param t Type of the subtree root.
+     * @param subtree_ Subtree to inspect for `Inf` leaf IDs.
+     * @return A freshly initialized context for that subtree.
+     */
+    static NodeContext create_subtree_sh_context(TreeType t, const check_macrostate& subtree_) {
+      NodeContext ctx;
+      collect_inf_leaf_ids(subtree_, ctx.leaf_ids);
+      if(t == TreeType::And && ctx.leaf_ids.size() > 0) {
+        ctx.type = NodeContextType::SHARED_BREAKPOINT;
+        ctx.leaf_id = ctx.leaf_ids[ctx.leaf_index % ctx.leaf_ids.size()];
+      }
+      return ctx;
+    }
+
+    bool operator==(const NodeContext& other) const = default;
+
+    std::strong_ordering operator<=>(const NodeContext& other) const {
+      if (this->type < other.type)
+        return std::strong_ordering::less;
+      if (other.type < this->type)
+        return std::strong_ordering::greater;
+
+      if (this->breakpoint < other.breakpoint)
+        return std::strong_ordering::less;
+      if (other.breakpoint < this->breakpoint)
+        return std::strong_ordering::greater;
+
+      if (this->leaf_id < other.leaf_id)
+        return std::strong_ordering::less;
+      if (other.leaf_id < this->leaf_id)
+        return std::strong_ordering::greater;
+
+      if (this->leaf_index < other.leaf_index)
+        return std::strong_ordering::less;
+      if (other.leaf_index < this->leaf_index)
+        return std::strong_ordering::greater;
+
+      if (this->leaf_ids < other.leaf_ids)
+        return std::strong_ordering::less;
+      if (other.leaf_ids < this->leaf_ids)
+        return std::strong_ordering::greater;
+
+      if (this->state < other.state)
+        return std::strong_ordering::less;
+      if (other.state < this->state)
+        return std::strong_ordering::greater;
+
+      return std::strong_ordering::equal;
+    }
+
+    /**
+     * @brief Merge this context with a predecessor context.
+     *
+     * Intended use: propagate a shared-breakpoint context top-down.
+     * If both this and @p predecessor are `SHARED_BREAKPOINT`, the predecessor
+     * is kept (so the shared-breakpoint state is effectively inherited).
+     * Otherwise this context is kept.
+     *
+     * @param predecessor Context from the parent node.
+     * @return Reference to the context that should be used downstream.
+     */
     NodeContext& merge_contexts(NodeContext& predecessor) {
       if (this->type == NodeContextType::NONE) {
         return *this;
@@ -69,6 +194,18 @@ namespace sd_inductive {
         return predecessor;
       } 
       return *this;
+    }
+
+    /**
+     * @brief Check whether this context can be merged with @p predecessor.
+     *
+     * Currently, contexts are mergeable iff both are `SHARED_BREAKPOINT`.
+     *
+     * @param predecessor Context from the parent node.
+     * @return `true` if the two contexts are considered mergeable.
+     */
+    bool is_mergable(NodeContext& predecessor) {
+      return this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT;
     }
 
     void restrict_states(const std::set<unsigned>& forbidden) {
@@ -94,6 +231,7 @@ namespace sd_inductive {
     }
     os << ", leaf_id=" << ctx.leaf_id;
     os << ", breakpoint=" << std::to_string(ctx.breakpoint);
+    os << ", state=" << (int)ctx.state;
     os << "}";
     return os;
   }
@@ -117,24 +255,21 @@ namespace sd_inductive {
     bool operator==(const AndOrNode& other) const;
     std::strong_ordering operator<=>(const AndOrNode& other) const;
 
-    void set_context(const NodeContext& ctx) {
-      this->context = ctx;
-      if(this->context.leaf_ids.size() > 0) {
-        this->context.leaf_index = this->context.leaf_index % this->context.leaf_ids.size();
-        if(this->context.breakpoint.empty()) {
-          this->context.leaf_index = (this->context.leaf_index + 1) % this->context.leaf_ids.size();
-        }
-        this->context.leaf_id = this->context.leaf_ids[this->context.leaf_index];
-      }
+    bool is_satisfied() const {
+      return (this->context.type != NodeContextType::SHARED_BREAKPOINT || this->context.breakpoint.empty()) && this->context.state == NodeContextState::GLOBAL_WAIT;
     }
 
-    bool is_satisfied() const {
-      return this->context.type != NodeContextType::SHARED_BREAKPOINT || this->context.breakpoint.empty();
+    NodeContext get_succ_context(bool resample) const {
+      return this->context.get_succ_context(resample);
     }
 
     const NodeContext& get_context() const {
       return this->context;
     }
+
+    void set_context(const NodeContext& ctx) {
+      this->context = ctx;
+    } 
   };
 
   /**
@@ -449,6 +584,13 @@ namespace sd_inductive {
       return from_acc_code(default_options(), code);
     }
 
+    /// Re-initialize NodeContext for all internal nodes in this tree.
+    ///
+    /// This is intended to be called after leaf IDs have been assigned
+    /// (e.g., after parsing acceptance and running an ID-renaming pass),
+    /// because shared-breakpoint contexts depend on `inf_leaf::id`.
+    check_macrostate init_contexts() const;
+
     /// Compute successor macrostate(s) for this check tree node.
     std::vector<check_macrostate> get_succ(
       const spot::const_twa_graph_ptr&  aut,
@@ -521,45 +663,13 @@ namespace sd_inductive {
     : type(t),
       subtree(std::make_shared<check_macrostate>(std::move(subtree_))),
       context(std::move(context_)) {
-    this->context.leaf_ids.clear();
-    if (this->subtree) {
-      collect_inf_leaf_ids(*this->subtree, this->context.leaf_ids);
-    }
-    if(t == TreeType::And && this->context.leaf_ids.size() > 0) {
-      this->context.type = NodeContextType::SHARED_BREAKPOINT;
-      this->context.leaf_id = this->context.leaf_ids[this->context.leaf_index % this->context.leaf_ids.size()];
-    }
-    
-
-    // this->shared_breakpoint.clear();
-    // if (this->subtree && this->type == TreeType::And) {
-    //   const auto& opts = this->subtree->get_options();
-    //   if (opts.use_shared_breakpoint && !this->leaf_ids.empty()) {
-    //     const unsigned selected_leaf_id = this->leaf_ids[this->leaf_index % this->leaf_ids.size()];
-    //     (void)find_inf_leaf_breakpoint_by_id(*this->subtree, selected_leaf_id, this->shared_breakpoint);
-    //   }
-    // }
   }
 
   inline bool AndOrNode::operator==(const AndOrNode& other) const {
-    if (this->type != other.type) {
+    if (this->type != other.type)
       return false;
-    }
-    if (this->context.type != other.context.type) {
+    if (this->context != other.context)
       return false;
-    }
-    if (this->context.breakpoint != other.context.breakpoint) {
-      return false;
-    }
-    if (this->context.leaf_id != other.context.leaf_id) {
-      return false;
-    }
-    if (this->context.leaf_index != other.context.leaf_index) {
-      return false;
-    }
-    if (this->context.leaf_ids != other.context.leaf_ids) {
-      return false;
-    }
 
     if (!this->subtree && !other.subtree) {
       return true;
@@ -578,37 +688,8 @@ namespace sd_inductive {
       return std::strong_ordering::greater;
     }
 
-    // Context ordering (lexicographic by individual fields)
-    if (this->context.type < other.context.type) {
-      return std::strong_ordering::less;
-    }
-    if (other.context.type < this->context.type) {
-      return std::strong_ordering::greater;
-    }
-    if (this->context.breakpoint < other.context.breakpoint) {
-      return std::strong_ordering::less;
-    }
-    if (other.context.breakpoint < this->context.breakpoint) {
-      return std::strong_ordering::greater;
-    }
-    if (this->context.leaf_id < other.context.leaf_id) {
-      return std::strong_ordering::less;
-    }
-    if (other.context.leaf_id < this->context.leaf_id) {
-      return std::strong_ordering::greater;
-    }
-    if (this->context.leaf_index < other.context.leaf_index) {
-      return std::strong_ordering::less;
-    }
-    if (other.context.leaf_index < this->context.leaf_index) {
-      return std::strong_ordering::greater;
-    }
-    if (this->context.leaf_ids < other.context.leaf_ids) {
-      return std::strong_ordering::less;
-    }
-    if (other.context.leaf_ids < this->context.leaf_ids) {
-      return std::strong_ordering::greater;
-    }
+    if (auto cmp = (this->context <=> other.context); cmp != std::strong_ordering::equal)
+      return cmp;
 
     // Same type and context: order by subtree presence then subtree structure.
     if (!this->subtree && !other.subtree) {

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -50,20 +50,35 @@ namespace sd_inductive {
 
   class check_macrostate;
 
+  struct NodeContext;
+  std::ostream& operator<<(std::ostream& os, const NodeContext& ctx);
+
   struct NodeContext {
     NodeContextType type { NodeContextType::NONE };
 
-    std::optional<std::reference_wrapper<std::set<unsigned>>> breakpoint;
+    std::set<unsigned> breakpoint {};
     unsigned leaf_id {0};
+    unsigned leaf_index {0};
+    std::vector<unsigned> leaf_ids {};
 
-    NodeContext merge_contexts(const NodeContext& predecessor) const {
+    NodeContext& merge_contexts(NodeContext& predecessor) {
       if (this->type == NodeContextType::NONE) {
-        return predecessor;
+        return *this;
       }
       if(this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT) {
         return predecessor;
       } 
       return *this;
+    }
+
+    void restrict_states(const std::set<unsigned>& forbidden) {
+      this->breakpoint = get_set_difference(this->breakpoint, forbidden);
+    }
+
+    std::string to_string() const {
+      std::ostringstream os;
+      os << *this;
+      return os.str();
     }
   };
 
@@ -78,11 +93,7 @@ namespace sd_inductive {
         break;
     }
     os << ", leaf_id=" << ctx.leaf_id;
-    if (ctx.breakpoint.has_value()) {
-      os << ", breakpoint=" << std::to_string(ctx.breakpoint->get());
-    } else {
-      os << ", breakpoint=<none>";
-    }
+    os << ", breakpoint=" << std::to_string(ctx.breakpoint);
     os << "}";
     return os;
   }
@@ -98,23 +109,32 @@ namespace sd_inductive {
     TreeType type {TreeType::And};
     std::shared_ptr<check_macrostate> subtree {};
 
-    mutable std::set<unsigned> shared_breakpoint {};
-    std::vector<unsigned> leaf_ids {};
-    mutable unsigned leaf_index {0};
+    NodeContext context{};
 
     AndOrNode() = default;
-    AndOrNode(TreeType t, check_macrostate subtree_);
+    AndOrNode(TreeType t, check_macrostate subtree_, NodeContext context_);
 
     bool operator==(const AndOrNode& other) const;
     std::strong_ordering operator<=>(const AndOrNode& other) const;
 
-    NodeContext get_context() const {
-      if(this->type == TreeType::And && !this->leaf_ids.empty()) {
-        this->leaf_index = this->leaf_index % this->leaf_ids.size();
-        return NodeContext{ NodeContextType::SHARED_BREAKPOINT, std::optional<std::reference_wrapper<std::set<unsigned>>>(std::ref(this->shared_breakpoint)),  this->leaf_ids[this->leaf_index] };
-      } else {
-        return NodeContext{ NodeContextType::NONE, std::nullopt, 0};
+    void set_context(const NodeContext& ctx) {
+      this->context = ctx;
+      this->context.leaf_index = this->context.leaf_index % this->context.leaf_ids.size();
+      if(this->context.breakpoint.empty() && this->context.leaf_ids.size() > 0) {
+        this->context.leaf_index = (this->context.leaf_index + 1) % this->context.leaf_ids.size();
       }
+      if(!this->context.leaf_ids.empty()) {
+        this->context.leaf_id = this->context.leaf_ids[this->context.leaf_index];
+      }
+      
+    }
+
+    bool is_satisfied() const {
+      return this->context.type != NodeContextType::SHARED_BREAKPOINT || this->context.breakpoint.empty();
+    }
+
+    const NodeContext& get_context() const {
+      return this->context;
     }
   };
 
@@ -177,7 +197,7 @@ namespace sd_inductive {
       options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
-      const NodeContext&                context) const;
+      NodeContext&                      context) const;
 
     bool is_satisfied() const;
   };
@@ -241,7 +261,7 @@ namespace sd_inductive {
       options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
-      const NodeContext&                context) const;
+      NodeContext&                      context) const;
 
     bool is_satisfied() const;
 
@@ -388,18 +408,18 @@ namespace sd_inductive {
      * @param right Right subtree.
      * @return A `check_macrostate` internal node.
      */
-    static check_macrostate make(options_ptr opts, TreeType type, check_macrostate left, check_macrostate right) {
+    static check_macrostate make(options_ptr opts, TreeType type, check_macrostate left, check_macrostate right, NodeContext node_payload = NodeContext{}) {
       // Build a concrete subtree rooted at this internal node.
       // We intentionally construct this subtree using a default internal
       // payload, and store it in the node payload for now.
       check_macrostate subtree_root(opts, base_tree::make_node(type, base_tree(left), base_tree(right)));
       base_tree l(std::move(left));
       base_tree r(std::move(right));
-      return check_macrostate(std::move(opts), base_tree::make_node(type, AndOrNode(type, std::move(subtree_root)), std::move(l), std::move(r)));
+      return check_macrostate(std::move(opts), base_tree::make_node(type, AndOrNode(type, std::move(subtree_root), std::move(node_payload)), std::move(l), std::move(r)));
     }
 
-    static check_macrostate make(TreeType type, check_macrostate left, check_macrostate right) {
-      return make(left.get_options_ptr(), type, std::move(left), std::move(right));
+    static check_macrostate make(TreeType type, check_macrostate left, check_macrostate right, NodeContext node_payload = NodeContext{}) {
+      return make(left.get_options_ptr(), type, std::move(left), std::move(right), std::move(node_payload));
     }
 
     /**
@@ -437,7 +457,7 @@ namespace sd_inductive {
       const std::set<unsigned>&         check_states,
       const bdd&                        bdd,
       bool                              resample,
-      const NodeContext&                parent_context = NodeContext{}) const;
+      NodeContext&                      parent_context) const;
 
     /// Check whether this macrostate check tree is satisfied.
     bool is_satisfied() const;
@@ -491,35 +511,26 @@ namespace sd_inductive {
       }
       return;
     }
+    if(bt.type() != TreeType::And) {
+      return;
+    }
     collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.left())), out);
     collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), out);
   }
 
-  // inline bool find_inf_leaf_breakpoint_by_id(const check_macrostate& t, unsigned id, std::set<unsigned>& out) {
-  //   using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
-  //   const base_tree& bt = static_cast<const base_tree&>(t);
-  //   if (bt.is_leaf()) {
-  //     if (bt.type() == TreeType::Inf) {
-  //       const auto& leaf = std::get<inf_leaf>(bt.leaf_value());
-  //       if (leaf.id == id) {
-  //         out = leaf.breakpoint;
-  //         return true;
-  //       }
-  //     }
-  //     return false;
-  //   }
-  //   return find_inf_leaf_breakpoint_by_id(check_macrostate(t.get_options_ptr(), base_tree(bt.left())), id, out) ||
-  //          find_inf_leaf_breakpoint_by_id(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), id, out);
-  // }
-
-  inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_)
+  inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_, NodeContext context_)
     : type(t),
-      subtree(std::make_shared<check_macrostate>(std::move(subtree_))) {
-    this->leaf_ids.clear();
+      subtree(std::make_shared<check_macrostate>(std::move(subtree_))),
+      context(std::move(context_)) {
+    this->context.leaf_ids.clear();
     if (this->subtree) {
-      collect_inf_leaf_ids(*this->subtree, this->leaf_ids);
+      collect_inf_leaf_ids(*this->subtree, this->context.leaf_ids);
     }
-    this->leaf_index = 0;
+    if(t == TreeType::And && this->context.leaf_ids.size() > 0) {
+      this->context.type = NodeContextType::SHARED_BREAKPOINT;
+      this->context.leaf_id = this->context.leaf_ids[this->context.leaf_index % this->context.leaf_ids.size()];
+    }
+    
 
     // this->shared_breakpoint.clear();
     // if (this->subtree && this->type == TreeType::And) {
@@ -535,6 +546,22 @@ namespace sd_inductive {
     if (this->type != other.type) {
       return false;
     }
+    if (this->context.type != other.context.type) {
+      return false;
+    }
+    if (this->context.breakpoint != other.context.breakpoint) {
+      return false;
+    }
+    if (this->context.leaf_id != other.context.leaf_id) {
+      return false;
+    }
+    if (this->context.leaf_index != other.context.leaf_index) {
+      return false;
+    }
+    if (this->context.leaf_ids != other.context.leaf_ids) {
+      return false;
+    }
+
     if (!this->subtree && !other.subtree) {
       return true;
     }
@@ -552,7 +579,39 @@ namespace sd_inductive {
       return std::strong_ordering::greater;
     }
 
-    // Same type: order by subtree presence then subtree structure.
+    // Context ordering (lexicographic by individual fields)
+    if (this->context.type < other.context.type) {
+      return std::strong_ordering::less;
+    }
+    if (other.context.type < this->context.type) {
+      return std::strong_ordering::greater;
+    }
+    if (this->context.breakpoint < other.context.breakpoint) {
+      return std::strong_ordering::less;
+    }
+    if (other.context.breakpoint < this->context.breakpoint) {
+      return std::strong_ordering::greater;
+    }
+    if (this->context.leaf_id < other.context.leaf_id) {
+      return std::strong_ordering::less;
+    }
+    if (other.context.leaf_id < this->context.leaf_id) {
+      return std::strong_ordering::greater;
+    }
+    if (this->context.leaf_index < other.context.leaf_index) {
+      return std::strong_ordering::less;
+    }
+    if (other.context.leaf_index < this->context.leaf_index) {
+      return std::strong_ordering::greater;
+    }
+    if (this->context.leaf_ids < other.context.leaf_ids) {
+      return std::strong_ordering::less;
+    }
+    if (other.context.leaf_ids < this->context.leaf_ids) {
+      return std::strong_ordering::greater;
+    }
+
+    // Same type and context: order by subtree presence then subtree structure.
     if (!this->subtree && !other.subtree) {
       return std::strong_ordering::equal;
     }

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -305,11 +305,7 @@ namespace sd_inductive {
      */
     explicit check_macrostate(options_ptr opts, base_tree tree)
       : base_tree(std::move(tree)),
-        opts_(std::move(opts)) {
-      if (!opts_) {
-        throw std::invalid_argument("check_macrostate: options must not be null");
-      }
-    }
+        opts_(opts ? std::move(opts) : default_options()) {}
 
     static options_ptr default_options() {
       static const options_ptr opts = std::make_shared<options>();

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -119,14 +119,13 @@ namespace sd_inductive {
 
     void set_context(const NodeContext& ctx) {
       this->context = ctx;
-      this->context.leaf_index = this->context.leaf_index % this->context.leaf_ids.size();
-      if(this->context.breakpoint.empty() && this->context.leaf_ids.size() > 0) {
-        this->context.leaf_index = (this->context.leaf_index + 1) % this->context.leaf_ids.size();
-      }
-      if(!this->context.leaf_ids.empty()) {
+      if(this->context.leaf_ids.size() > 0) {
+        this->context.leaf_index = this->context.leaf_index % this->context.leaf_ids.size();
+        if(this->context.breakpoint.empty()) {
+          this->context.leaf_index = (this->context.leaf_index + 1) % this->context.leaf_ids.size();
+        }
         this->context.leaf_id = this->context.leaf_ids[this->context.leaf_index];
       }
-      
     }
 
     bool is_satisfied() const {

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -6,9 +6,11 @@
 
 #include <compare>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -21,6 +23,12 @@
 namespace kofola { // {{{
 
 namespace sd_inductive {
+
+  struct options {
+    bool use_shared_breakpoint{false};
+  };
+
+  using options_ptr = std::shared_ptr<const options>;
 
   /**
    * @brief Type of a node in a `check_macrostate` tree.
@@ -146,6 +154,7 @@ namespace sd_inductive {
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
+      options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
       const NodeContext&                context) const;
@@ -209,6 +218,7 @@ namespace sd_inductive {
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
+      options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
       const NodeContext&                context) const;
@@ -290,9 +300,24 @@ namespace sd_inductive {
     /**
      * @brief Construct a `check_macrostate` from an already-built base tree.
      *
+     * @param opts Options shared by all nodes in this check tree.
      * @param tree Underlying tree representation.
      */
-    explicit check_macrostate(base_tree tree) : base_tree(std::move(tree)) {}
+    explicit check_macrostate(options_ptr opts, base_tree tree)
+      : base_tree(std::move(tree)),
+        opts_(std::move(opts)) {
+      if (!opts_) {
+        throw std::invalid_argument("check_macrostate: options must not be null");
+      }
+    }
+
+    static options_ptr default_options() {
+      static const options_ptr opts = std::make_shared<options>();
+      return opts;
+    }
+
+    const options& get_options() const { return *opts_; }
+    const options_ptr& get_options_ptr() const { return opts_; }
 
     /**
      * @brief Build a `Fin` leaf.
@@ -300,12 +325,20 @@ namespace sd_inductive {
      * @param safe Set of safe states.
      * @return A `check_macrostate` leaf of type `TreeType::Fin`.
      */
+    static check_macrostate fin(options_ptr opts, std::set<unsigned> safe, spot::acc_cond::mark_t color) {
+      return check_macrostate(std::move(opts), base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, 0}));
+    }
+
+    static check_macrostate fin(options_ptr opts, std::set<unsigned> safe, spot::acc_cond::mark_t color, unsigned id) {
+      return check_macrostate(std::move(opts), base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, id}));
+    }
+
     static check_macrostate fin(std::set<unsigned> safe, spot::acc_cond::mark_t color) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, 0}));
+      return fin(default_options(), std::move(safe), color);
     }
 
     static check_macrostate fin(std::set<unsigned> safe, spot::acc_cond::mark_t color, unsigned id) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, id}));
+      return fin(default_options(), std::move(safe), color, id);
     }
 
     /**
@@ -315,12 +348,20 @@ namespace sd_inductive {
      * @param breakpoint Breakpoint set.
      * @return A `check_macrostate` leaf of type `TreeType::Inf`.
      */
+    static check_macrostate inf(options_ptr opts, std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color) {
+      return check_macrostate(std::move(opts), base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, 0}));
+    }
+
+    static check_macrostate inf(options_ptr opts, std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color, unsigned id) {
+      return check_macrostate(std::move(opts), base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, id}));
+    }
+
     static check_macrostate inf(std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, 0}));
+      return inf(default_options(), std::move(track), std::move(breakpoint), color);
     }
 
     static check_macrostate inf(std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color, unsigned id) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, id}));
+      return inf(default_options(), std::move(track), std::move(breakpoint), color, id);
     }
 
     /**
@@ -331,14 +372,18 @@ namespace sd_inductive {
      * @param right Right subtree.
      * @return A `check_macrostate` internal node.
      */
-    static check_macrostate make(TreeType type, check_macrostate left, check_macrostate right) {
+    static check_macrostate make(options_ptr opts, TreeType type, check_macrostate left, check_macrostate right) {
       // Build a concrete subtree rooted at this internal node.
       // We intentionally construct this subtree using a default internal
       // payload, and store it in the node payload for now.
-      check_macrostate subtree_root(base_tree::make_node(type, base_tree(left), base_tree(right)));
+      check_macrostate subtree_root(opts, base_tree::make_node(type, base_tree(left), base_tree(right)));
       base_tree l(std::move(left));
       base_tree r(std::move(right));
-      return check_macrostate(base_tree::make_node(type, AndOrNode(type, std::move(subtree_root)), std::move(l), std::move(r)));
+      return check_macrostate(std::move(opts), base_tree::make_node(type, AndOrNode(type, std::move(subtree_root)), std::move(l), std::move(r)));
+    }
+
+    static check_macrostate make(TreeType type, check_macrostate left, check_macrostate right) {
+      return make(left.get_options_ptr(), type, std::move(left), std::move(right));
     }
 
     /**
@@ -363,7 +408,11 @@ namespace sd_inductive {
     }
 
     /// Build a `check_macrostate` tree from a Spot acceptance formula.
-    static check_macrostate from_acc_code(const spot::acc_cond::acc_code& code);
+    static check_macrostate from_acc_code(options_ptr opts, const spot::acc_cond::acc_code& code);
+
+    static check_macrostate from_acc_code(const spot::acc_cond::acc_code& code) {
+      return from_acc_code(default_options(), code);
+    }
 
     /// Compute successor macrostate(s) for this check tree node.
     std::vector<check_macrostate> get_succ(
@@ -393,9 +442,9 @@ namespace sd_inductive {
 
   private:
 
-    static check_macrostate fold(TreeType op, const std::vector<spot::acc_cond::acc_code>& parts);
+    static check_macrostate fold(options_ptr opts, TreeType op, const std::vector<spot::acc_cond::acc_code>& parts);
 
-    static check_macrostate from_acc_code_impl(const spot::acc_cond::acc_code& code);
+    static check_macrostate from_acc_code_impl(options_ptr opts, const spot::acc_cond::acc_code& code);
 
     /**
      * @brief Convert `TreeType` to a stable string name.
@@ -412,6 +461,9 @@ namespace sd_inductive {
      * @return String representation of @p tree.
      */
     static std::string to_string_impl(const base_tree& tree);
+
+  private:
+    options_ptr opts_;
   };
 
   inline void collect_inf_leaf_ids(const check_macrostate& t, std::vector<unsigned>& out) {
@@ -426,8 +478,8 @@ namespace sd_inductive {
       }
       return;
     }
-    collect_inf_leaf_ids(check_macrostate(base_tree(bt.left())), out);
-    collect_inf_leaf_ids(check_macrostate(base_tree(bt.right())), out);
+    collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.left())), out);
+    collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), out);
   }
 
   inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_)
@@ -583,6 +635,7 @@ public:
 // DATA MEMBERS
 private:
   spot::acc_cond::acc_code acc_cond_ {};
+  sd_inductive::options_ptr opts_ { nullptr };
 }; // complement_sd_inductive }}}
 
 

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -35,7 +35,29 @@ namespace sd_inductive {
     Or
   };
 
+  enum class NodeContextType {
+    NONE,
+    SHARED_BREAKPOINT
+  };
+
   class check_macrostate;
+
+  struct NodeContext {
+    NodeContextType type { NodeContextType::NONE };
+
+    std::optional<std::reference_wrapper<std::set<unsigned>>> breakpoint;
+    unsigned leaf_id {0};
+
+    NodeContext merge_contexts(const NodeContext& predecessor) const {
+      if(this->type == NodeContextType::NONE) {
+        return *this;
+      }
+      if(this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT) {
+        return predecessor;
+      } 
+      return *this;
+    }
+  };
 
   /**
    * @brief Payload of an internal `And`/`Or` node in `check_macrostate`.
@@ -48,11 +70,24 @@ namespace sd_inductive {
     TreeType type {TreeType::And};
     std::shared_ptr<check_macrostate> subtree {};
 
+    mutable std::set<unsigned> shared_breakpoint {};
+    std::vector<unsigned> leaf_ids {};
+    mutable unsigned leaf_index {0};
+
     AndOrNode() = default;
     AndOrNode(TreeType t, check_macrostate subtree_);
 
     bool operator==(const AndOrNode& other) const;
     std::strong_ordering operator<=>(const AndOrNode& other) const;
+
+    NodeContext get_context() const {
+      if(this->type == TreeType::And && !this->leaf_ids.empty()) {
+        this->leaf_index = this->leaf_index % this->leaf_ids.size();
+        return NodeContext{ NodeContextType::SHARED_BREAKPOINT, std::optional<std::reference_wrapper<std::set<unsigned>>>(std::ref(this->shared_breakpoint)),  this->leaf_ids[this->leaf_index] };
+      } else {
+        return NodeContext{ NodeContextType::NONE, std::nullopt, 0};
+      }
+    }
   };
 
   /**
@@ -64,6 +99,9 @@ namespace sd_inductive {
     std::set<unsigned> safe {};
     /** @brief Acceptance color associated with this Fin-check. */
     spot::acc_cond::mark_t color {}; 
+
+    /** @brief Unique numeric id of this leaf within a check tree. */
+    unsigned id {0};
 
     static std::string mark_to_string(const spot::acc_cond::mark_t& m) {
       std::ostringstream os;
@@ -89,6 +127,10 @@ namespace sd_inductive {
     bool operator==(const fin_leaf&) const = default;
 
     std::strong_ordering operator<=>(const fin_leaf& other) const {
+      if (this->id < other.id)
+        return std::strong_ordering::less;
+      if (other.id < this->id)
+        return std::strong_ordering::greater;
       if (this->safe < other.safe)
         return std::strong_ordering::less;
       if (other.safe < this->safe)
@@ -105,7 +147,8 @@ namespace sd_inductive {
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       const bdd&                        bdd,
-      bool                              resample) const;
+      bool                              resample,
+      const NodeContext&                context) const;
 
     bool is_satisfied() const;
   };
@@ -120,6 +163,9 @@ namespace sd_inductive {
     std::set<unsigned> breakpoint {};
     /** @brief Acceptance color associated with this Inf-check. */
     spot::acc_cond::mark_t color {}; 
+
+    /** @brief Unique numeric id of this leaf within a check tree. */
+    unsigned id {0};
 
     /**
      * @brief Convert this leaf payload into a human-readable string.
@@ -140,6 +186,10 @@ namespace sd_inductive {
     bool operator==(const inf_leaf&) const = default;
 
     std::strong_ordering operator<=>(const inf_leaf& other) const {
+      if (this->id < other.id)
+        return std::strong_ordering::less;
+      if (other.id < this->id)
+        return std::strong_ordering::greater;
       if (this->track < other.track)
         return std::strong_ordering::less;
       if (other.track < this->track)
@@ -160,7 +210,8 @@ namespace sd_inductive {
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       const bdd&                        bdd,
-      bool                              resample) const;
+      bool                              resample,
+      const NodeContext&                context) const;
 
     bool is_satisfied() const;
 
@@ -250,7 +301,11 @@ namespace sd_inductive {
      * @return A `check_macrostate` leaf of type `TreeType::Fin`.
      */
     static check_macrostate fin(std::set<unsigned> safe, spot::acc_cond::mark_t color) {
-      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color}));
+      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, 0}));
+    }
+
+    static check_macrostate fin(std::set<unsigned> safe, spot::acc_cond::mark_t color, unsigned id) {
+      return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{std::move(safe), color, id}));
     }
 
     /**
@@ -261,7 +316,11 @@ namespace sd_inductive {
      * @return A `check_macrostate` leaf of type `TreeType::Inf`.
      */
     static check_macrostate inf(std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color) {
-      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color}));
+      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, 0}));
+    }
+
+    static check_macrostate inf(std::set<unsigned> track, std::set<unsigned> breakpoint, spot::acc_cond::mark_t color, unsigned id) {
+      return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{std::move(track), std::move(breakpoint), color, id}));
     }
 
     /**
@@ -312,7 +371,8 @@ namespace sd_inductive {
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       const bdd&                        bdd,
-      bool                              resample) const;
+      bool                              resample,
+      const NodeContext&                parent_context = NodeContext{}) const;
 
     /// Check whether this macrostate check tree is satisfied.
     bool is_satisfied() const;
@@ -354,9 +414,31 @@ namespace sd_inductive {
     static std::string to_string_impl(const base_tree& tree);
   };
 
+  inline void collect_inf_leaf_ids(const check_macrostate& t, std::vector<unsigned>& out) {
+    using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
+    const base_tree& bt = static_cast<const base_tree&>(t);
+    if(bt.type() != TreeType::And) {
+      return;
+    }
+    if (bt.is_leaf()) {
+      if (bt.type() == TreeType::Inf) {
+        out.push_back(std::get<inf_leaf>(bt.leaf_value()).id);
+      }
+      return;
+    }
+    collect_inf_leaf_ids(check_macrostate(base_tree(bt.left())), out);
+    collect_inf_leaf_ids(check_macrostate(base_tree(bt.right())), out);
+  }
+
   inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_)
     : type(t),
-      subtree(std::make_shared<check_macrostate>(std::move(subtree_))) {}
+      subtree(std::make_shared<check_macrostate>(std::move(subtree_))) {
+    this->leaf_ids.clear();
+    if (this->subtree) {
+      collect_inf_leaf_ids(*this->subtree, this->leaf_ids);
+    }
+    this->leaf_index = 0;
+  }
 
   inline bool AndOrNode::operator==(const AndOrNode& other) const {
     if (this->type != other.type) {

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -655,8 +655,8 @@ namespace sd_inductive {
     if(bt.type() != TreeType::And) {
       return;
     }
-    collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.left())), out);
-    collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), out);
+    collect_inf_leaf_ids(check_macrostate(nullptr, base_tree(bt.left())), out);
+    collect_inf_leaf_ids(check_macrostate(nullptr, base_tree(bt.right())), out);
   }
 
   inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_, NodeContext context_)

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -178,9 +178,9 @@ namespace sd_inductive {
    * - node type: `TreeType`
    * - leaf payload: `fin_leaf` or `inf_leaf`
    */
-  class check_macrostate : public kofola::types::binary_tree<TreeType, fin_leaf, inf_leaf> {
+  class check_macrostate : public kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf> {
     /** @brief Base tree type used for representation. */
-    using base_tree = kofola::types::binary_tree<TreeType, fin_leaf, inf_leaf>;
+    using base_tree = kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf>;
 
   public:
     /** @brief Deleted default constructor (a check must be a leaf or a node). */

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -56,6 +56,16 @@ namespace sd_inductive {
 
   class check_macrostate;
 
+  /**
+   * @brief Collect IDs of `Inf` leaves under `And` nodes.
+   *
+   * Traverses the check tree @p t and appends each encountered
+   * `inf_leaf::id` to @p out. For internal nodes, only `TreeType::And`
+   * subtrees are traversed; `Or` subtrees are intentionally ignored.
+   *
+   * @param t   Check tree (subtree root) to traverse.
+   * @param out Output vector to append leaf IDs into.
+   */
   inline void collect_inf_leaf_ids(const check_macrostate& t, std::vector<unsigned>& out);
 
   struct NodeContext;

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -57,8 +57,8 @@ namespace sd_inductive {
     unsigned leaf_id {0};
 
     NodeContext merge_contexts(const NodeContext& predecessor) const {
-      if(this->type == NodeContextType::NONE) {
-        return *this;
+      if (this->type == NodeContextType::NONE) {
+        return predecessor;
       }
       if(this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT) {
         return predecessor;
@@ -66,6 +66,26 @@ namespace sd_inductive {
       return *this;
     }
   };
+
+  inline std::ostream& operator<<(std::ostream& os, const NodeContext& ctx) {
+    os << "NodeContext{";
+    switch (ctx.type) {
+      case NodeContextType::NONE:
+        os << "type=NONE";
+        break;
+      case NodeContextType::SHARED_BREAKPOINT:
+        os << "type=SHARED_BREAKPOINT";
+        break;
+    }
+    os << ", leaf_id=" << ctx.leaf_id;
+    if (ctx.breakpoint.has_value()) {
+      os << ", breakpoint=" << std::to_string(ctx.breakpoint->get());
+    } else {
+      os << ", breakpoint=<none>";
+    }
+    os << "}";
+    return os;
+  }
 
   /**
    * @brief Payload of an internal `And`/`Or` node in `check_macrostate`.
@@ -388,7 +408,7 @@ namespace sd_inductive {
      * @return String representation of this macrostate check tree.
      */
     std::string to_string() const {
-      return to_string_impl(static_cast<const base_tree&>(*this));
+      return to_string_impl(static_cast<const base_tree&>(*this), opts_ && opts_->use_shared_breakpoint);
     }
 
     /**
@@ -456,7 +476,7 @@ namespace sd_inductive {
      * @param tree Tree to print.
      * @return String representation of @p tree.
      */
-    static std::string to_string_impl(const base_tree& tree);
+    static std::string to_string_impl(const base_tree& tree, bool show_shared_breakpoint);
 
   private:
     options_ptr opts_;
@@ -465,9 +485,6 @@ namespace sd_inductive {
   inline void collect_inf_leaf_ids(const check_macrostate& t, std::vector<unsigned>& out) {
     using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
     const base_tree& bt = static_cast<const base_tree&>(t);
-    if(bt.type() != TreeType::And) {
-      return;
-    }
     if (bt.is_leaf()) {
       if (bt.type() == TreeType::Inf) {
         out.push_back(std::get<inf_leaf>(bt.leaf_value()).id);
@@ -478,6 +495,23 @@ namespace sd_inductive {
     collect_inf_leaf_ids(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), out);
   }
 
+  // inline bool find_inf_leaf_breakpoint_by_id(const check_macrostate& t, unsigned id, std::set<unsigned>& out) {
+  //   using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
+  //   const base_tree& bt = static_cast<const base_tree&>(t);
+  //   if (bt.is_leaf()) {
+  //     if (bt.type() == TreeType::Inf) {
+  //       const auto& leaf = std::get<inf_leaf>(bt.leaf_value());
+  //       if (leaf.id == id) {
+  //         out = leaf.breakpoint;
+  //         return true;
+  //       }
+  //     }
+  //     return false;
+  //   }
+  //   return find_inf_leaf_breakpoint_by_id(check_macrostate(t.get_options_ptr(), base_tree(bt.left())), id, out) ||
+  //          find_inf_leaf_breakpoint_by_id(check_macrostate(t.get_options_ptr(), base_tree(bt.right())), id, out);
+  // }
+
   inline AndOrNode::AndOrNode(TreeType t, check_macrostate subtree_)
     : type(t),
       subtree(std::make_shared<check_macrostate>(std::move(subtree_))) {
@@ -486,6 +520,15 @@ namespace sd_inductive {
       collect_inf_leaf_ids(*this->subtree, this->leaf_ids);
     }
     this->leaf_index = 0;
+
+    // this->shared_breakpoint.clear();
+    // if (this->subtree && this->type == TreeType::And) {
+    //   const auto& opts = this->subtree->get_options();
+    //   if (opts.use_shared_breakpoint && !this->leaf_ids.empty()) {
+    //     const unsigned selected_leaf_id = this->leaf_ids[this->leaf_index % this->leaf_ids.size()];
+    //     (void)find_inf_leaf_breakpoint_by_id(*this->subtree, selected_leaf_id, this->shared_breakpoint);
+    //   }
+    // }
   }
 
   inline bool AndOrNode::operator==(const AndOrNode& other) const {

--- a/src/types/binary_tree.hpp
+++ b/src/types/binary_tree.hpp
@@ -150,8 +150,12 @@ public:
   /** Returns the left subtree (only valid when `is_node() == true`). */
   const binary_tree& left() const { return *left_; }
 
+  binary_tree& left() { return *left_; }
+
   /** Returns the right subtree (only valid when `is_node() == true`). */
   const binary_tree& right() const { return *right_; }
+
+  binary_tree& right() { return *right_; }
 
   /** Structural equality comparison (compares type, kind, and payload/children). */
   friend bool operator==(const binary_tree& a, const binary_tree& b) {

--- a/src/types/binary_tree.hpp
+++ b/src/types/binary_tree.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -28,10 +29,11 @@ concept totally_ordered = std::totally_ordered<T>;
  * - For leaves, payload is ordered by `std::variant` (index then value)
  * - For internal nodes, children are ordered lexicographically (left, right)
  */
-template <class NodeType, class... LeafTypes>
+template <class NodeType, class InternalValue = std::monostate, class... LeafTypes>
 class binary_tree {
   static_assert(sizeof...(LeafTypes) > 0, "binary_tree requires at least one leaf type");
   static_assert(totally_ordered<NodeType>, "NodeType must be totally ordered");
+  static_assert(totally_ordered<InternalValue>, "InternalValue must be totally ordered");
   static_assert((totally_ordered<LeafTypes> && ...), "All leaf types must be totally ordered");
 
 public:
@@ -45,6 +47,7 @@ private:
   kind kind_;
   NodeType type_;
   std::optional<leaf_variant> leaf_value_;
+  std::optional<InternalValue> node_value_;
   std::unique_ptr<binary_tree> left_;
   std::unique_ptr<binary_tree> right_;
 
@@ -84,7 +87,19 @@ public:
    * @param right Right subtree.
    */
   static binary_tree make_node(NodeType type, binary_tree left, binary_tree right) {
-    return binary_tree(std::move(type), std::move(left), std::move(right));
+    return binary_tree(std::move(type), InternalValue{}, std::move(left), std::move(right));
+  }
+
+  /**
+   * Construct an internal node with payload and two children.
+   *
+   * @param type  Logical type associated with this internal node.
+   * @param v     Internal-node payload.
+   * @param left  Left subtree.
+   * @param right Right subtree.
+   */
+  static binary_tree make_node(NodeType type, InternalValue v, binary_tree left, binary_tree right) {
+    return binary_tree(std::move(type), std::move(v), std::move(left), std::move(right));
   }
 
   /** Deep-copy constructor (recursively copies the subtree). */
@@ -92,6 +107,7 @@ public:
       : kind_(other.kind_),
         type_(other.type_),
         leaf_value_(other.leaf_value_),
+        node_value_(other.node_value_),
         left_(other.left_ ? std::make_unique<binary_tree>(*other.left_) : nullptr),
         right_(other.right_ ? std::make_unique<binary_tree>(*other.right_) : nullptr) {}
 
@@ -125,6 +141,9 @@ public:
   /** Returns the leaf payload (only valid when `is_leaf() == true`). */
   const leaf_variant& leaf_value() const { return *leaf_value_; }
 
+  /** Returns the internal-node payload (only valid when `is_node() == true`). */
+  const InternalValue& node_value() const { return *node_value_; }
+
   /** Returns the left subtree (only valid when `is_node() == true`). */
   const binary_tree& left() const { return *left_; }
 
@@ -138,6 +157,9 @@ public:
     }
     if (a.is_leaf()) {
       return a.leaf_value_ == b.leaf_value_;
+    }
+    if (!(a.node_value_ == b.node_value_)) {
+      return false;
     }
     return *a.left_ == *b.left_ && *a.right_ == *b.right_;
   }
@@ -170,6 +192,12 @@ public:
     }
 
     // Both are nodes (and same type).
+    if (*a.node_value_ < *b.node_value_) {
+      return true;
+    }
+    if (*b.node_value_ < *a.node_value_) {
+      return false;
+    }
     if (*a.left_ < *b.left_) {
       return true;
     }
@@ -194,14 +222,16 @@ private:
       : kind_(kind::leaf),
         type_(std::move(type)),
         leaf_value_(std::move(v)),
+        node_value_(std::nullopt),
         left_(nullptr),
         right_(nullptr) {}
 
   /** Private constructor for building internal nodes. */
-  binary_tree(NodeType type, binary_tree left, binary_tree right)
+    binary_tree(NodeType type, InternalValue v, binary_tree left, binary_tree right)
       : kind_(kind::node),
         type_(std::move(type)),
         leaf_value_(std::nullopt),
+        node_value_(std::move(v)),
         left_(std::make_unique<binary_tree>(std::move(left))),
         right_(std::make_unique<binary_tree>(std::move(right))) {}
 };

--- a/src/types/binary_tree.hpp
+++ b/src/types/binary_tree.hpp
@@ -144,6 +144,9 @@ public:
   /** Returns the internal-node payload (only valid when `is_node() == true`). */
   const InternalValue& node_value() const { return *node_value_; }
 
+  InternalValue& node_value() { return *node_value_; }
+
+
   /** Returns the left subtree (only valid when `is_node() == true`). */
   const binary_tree& left() const { return *left_; }
 

--- a/tests/inductive/test_check_macrostate_from_acc_code.cpp
+++ b/tests/inductive/test_check_macrostate_from_acc_code.cpp
@@ -17,14 +17,14 @@ static const auto& as_base(const check_macrostate& t) {
   return static_cast<const base_tree&>(t);
 }
 
-static check_macrostate fin_color(std::initializer_list<unsigned> idx) {
+static check_macrostate fin_color(std::initializer_list<unsigned> idx, unsigned id = 0) {
   const spot::acc_cond::mark_t m(idx.begin(), idx.end());
-  return check_macrostate(base_tree::leaf(TreeType::Fin, fin_leaf{{}, m}));
+  return check_macrostate::fin({}, m, id);
 }
 
-static check_macrostate inf_color(std::initializer_list<unsigned> idx) {
+static check_macrostate inf_color(std::initializer_list<unsigned> idx, unsigned id = 0) {
   const spot::acc_cond::mark_t m(idx.begin(), idx.end());
-  return check_macrostate(base_tree::leaf(TreeType::Inf, inf_leaf{{}, {}, m}));
+  return check_macrostate::inf({}, {}, m, id);
 }
 
 struct leaf_sig {
@@ -69,14 +69,14 @@ TEST_CASE("check_macrostate builds leaves from Spot acc_code", "[check_macrostat
   SECTION("Inf leaf") {
     auto code = spot::acc_cond::acc_code("Inf(0)");
     auto got = check_macrostate::from_acc_code(code);
-    auto exp = inf_color({0});
+    auto exp = inf_color({0}, 0);
     REQUIRE(as_base(got) == as_base(exp));
   }
 
   SECTION("Fin leaf") {
     auto code = spot::acc_cond::acc_code("Fin(2)");
     auto got = check_macrostate::from_acc_code(code);
-    auto exp = fin_color({2});
+    auto exp = fin_color({2}, 0);
     REQUIRE(as_base(got) == as_base(exp));
   }
 }
@@ -128,8 +128,8 @@ TEST_CASE("check_macrostate builds And/Or structure from Spot acc_code", "[check
     auto code = spot::acc_cond::acc_code("(Fin(0) & Inf(1)) | (Fin(2) & Inf(3))");
     auto got = check_macrostate::from_acc_code(code);
 
-    auto left = check_macrostate::make(TreeType::And, fin_color({0}), inf_color({1}));
-    auto right = check_macrostate::make(TreeType::And, fin_color({2}), inf_color({3}));
+    auto left = check_macrostate::make(TreeType::And, fin_color({0}, 0), inf_color({1}, 1));
+    auto right = check_macrostate::make(TreeType::And, fin_color({2}, 2), inf_color({3}, 3));
     auto exp = check_macrostate::make(TreeType::Or, std::move(left), std::move(right));
 
     REQUIRE(as_base(got) == as_base(exp));

--- a/tests/inductive/test_check_macrostate_from_acc_code.cpp
+++ b/tests/inductive/test_check_macrostate_from_acc_code.cpp
@@ -128,10 +128,24 @@ TEST_CASE("check_macrostate builds And/Or structure from Spot acc_code", "[check
     auto code = spot::acc_cond::acc_code("(Fin(0) & Inf(1)) | (Fin(2) & Inf(3))");
     auto got = check_macrostate::from_acc_code(code);
 
-    auto left = check_macrostate::make(TreeType::And, fin_color({0}, 0), inf_color({1}, 1));
-    auto right = check_macrostate::make(TreeType::And, fin_color({2}, 2), inf_color({3}, 3));
-    auto exp = check_macrostate::make(TreeType::Or, std::move(left), std::move(right));
+    // Spot may reorder conjuncts/disjuncts depending on version/platform.
+    // Verify the parsed tree shape and leaf multiset, ignoring IDs and ordering.
+    std::vector<TreeType> internal_types;
+    std::vector<leaf_sig> leaves;
+    collect(as_base(got), internal_types, leaves);
 
-    REQUIRE(as_base(got) == as_base(exp));
+    REQUIRE(internal_types.size() == 3);
+    REQUIRE(std::count(internal_types.begin(), internal_types.end(), TreeType::Or) == 1);
+    REQUIRE(std::count(internal_types.begin(), internal_types.end(), TreeType::And) == 2);
+
+    std::sort(leaves.begin(), leaves.end(), leaf_sig_less);
+    std::vector<leaf_sig> expected {
+      leaf_sig{TreeType::Fin, spot::acc_cond::mark_t{0}},
+      leaf_sig{TreeType::Fin, spot::acc_cond::mark_t{2}},
+      leaf_sig{TreeType::Inf, spot::acc_cond::mark_t{1}},
+      leaf_sig{TreeType::Inf, spot::acc_cond::mark_t{3}},
+    };
+    std::sort(expected.begin(), expected.end(), leaf_sig_less);
+    REQUIRE(leaves == expected);
   }
 }

--- a/tests/inductive/test_check_macrostate_from_acc_code.cpp
+++ b/tests/inductive/test_check_macrostate_from_acc_code.cpp
@@ -10,7 +10,7 @@ using kofola::sd_inductive::TreeType;
 using kofola::sd_inductive::check_macrostate;
 using kofola::sd_inductive::fin_leaf;
 using kofola::sd_inductive::inf_leaf;
-using base_tree = kofola::types::binary_tree<TreeType, fin_leaf, inf_leaf>;
+using base_tree = kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf>;
 
 static const auto& as_base(const check_macrostate& t) {
   return static_cast<const base_tree&>(t);

--- a/tests/inductive/test_check_macrostate_from_acc_code.cpp
+++ b/tests/inductive/test_check_macrostate_from_acc_code.cpp
@@ -8,9 +8,10 @@
 namespace {
 using kofola::sd_inductive::TreeType;
 using kofola::sd_inductive::check_macrostate;
+using kofola::sd_inductive::AndOrNode;
 using kofola::sd_inductive::fin_leaf;
 using kofola::sd_inductive::inf_leaf;
-using base_tree = kofola::types::binary_tree<TreeType, std::monostate, fin_leaf, inf_leaf>;
+using base_tree = kofola::types::binary_tree<TreeType, AndOrNode, fin_leaf, inf_leaf>;
 
 static const auto& as_base(const check_macrostate& t) {
   return static_cast<const base_tree&>(t);

--- a/tests/tela/test_complement_tela.cpp
+++ b/tests/tela/test_complement_tela.cpp
@@ -52,6 +52,28 @@ TEST_CASE("complement_tela with tela_det_alg=inductive produces language-equival
     kofola::OPTIONS.params.erase("tela_det_alg");
 }
 
+TEST_CASE("complement_tela with tela_det_alg=inductive and sd_ind_sh_break=yes produces language-equivalent results to Spot",
+          "[complement_tela][tela_det_alg][inductive][sd_ind_sh_break]") {
+    // Set up TELA options and enable inductive SD-TELA determinization with shared breakpoint
+    test_utils::setup_tela_options();
+    kofola::OPTIONS.params["tela_det_alg"] = "inductive";
+    kofola::OPTIONS.params["sd_ind_sh_break"] = "yes";
+
+    for (const std::string& filename : test_utils::COMMON_TEST_FILES) {
+        SECTION("Testing file (inductive det, shared breakpoint): " + filename) {
+            spot::twa_graph_ptr aut = test_utils::load_automaton_from_file(filename);
+            REQUIRE(aut != nullptr);
+
+            bool equivalent = test_utils::test_complement_equivalence(aut, false);
+            CHECK(equivalent);
+        }
+    }
+
+    // Clean up to avoid side-effects on other tests
+    kofola::OPTIONS.params.erase("sd_ind_sh_break");
+    kofola::OPTIONS.params.erase("tela_det_alg");
+}
+
 // Manual test function that can be called from main
 void run_complement_test_on_file(const std::string& filename) {
     std::cout << "Testing complement equivalence for file: " << filename << std::endl;

--- a/tests/test_data/tela_det/elev_out_3602.hoa
+++ b/tests/test_data/tela_det/elev_out_3602.hoa
@@ -1,0 +1,21 @@
+HOA: v1
+States: 4
+Start: 0
+AP: 2 "a" "b"
+Acceptance: 3 Inf(2) | (Fin(0)|Fin(1))
+properties: trans-labels explicit-labels trans-acc
+--BODY--
+State: 0
+[!0] 0 {0}
+[0] 0 {1}
+[0&1] 1
+State: 1
+[1] 1 {0 1}
+[1] 2
+[1] 3
+State: 2
+[0&1] 2 {2}
+State: 3
+[0&1] 3 {0 1}
+[!0&1] 3 {2}
+--END--

--- a/tests/test_data/tela_det/out_3602.hoa
+++ b/tests/test_data/tela_det/out_3602.hoa
@@ -1,0 +1,16 @@
+HOA: v1
+States: 2
+Start: 0
+AP: 2 "a" "b"
+Acceptance: 4 (Fin(2)|Fin(3)) & (Inf(1) | Fin(0))
+properties: trans-labels explicit-labels trans-acc
+--BODY--
+State: 0
+[!0] 0 {1 2}
+[0] 0 {3}
+[0&1] 1
+State: 1
+[0&1] 1 {0 2}
+[!0&1] 1 {1 2}
+[0&1] 1 {3}
+--END--

--- a/tests/types/test_binary_tree.cpp
+++ b/tests/types/test_binary_tree.cpp
@@ -8,7 +8,7 @@ namespace {
 
 enum class op_t { and_, or_ };
 
-using tree_t = kofola::types::binary_tree<op_t, int, std::string>;
+using tree_t = kofola::types::binary_tree<op_t, int, int, std::string>;
 
 } // namespace
 

--- a/tests/utils/test_utils.hpp
+++ b/tests/utils/test_utils.hpp
@@ -94,6 +94,7 @@ const std::vector<std::string> COMMON_TEST_FILES = {
     "tests/test_data/tela_det/automaton940.hoa",
     "tests/test_data/tela_det/out_1332.hoa",
     //"tests/test_data/tela_det/out_3357.hoa",
+    "tests/test_data/tela_det/elev_out_3602.hoa"
 };
 
 /**


### PR DESCRIPTION
This pull request introduces substantial improvements to the inductive TELA complementation algorithm, primarily to support and refine a shared breakpoint ("sb") mode for more efficient state management. The changes focus on enabling, propagating, and displaying shared breakpoints in the check tree, as well as improving correctness and maintainability through more explicit context and option handling.