### PR TITLE
Interface for determinization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 # Include subdirectories
 add_subdirectory(algorithms)
 add_subdirectory(complement)
+add_subdirectory(determinization)
 add_subdirectory(inclusion)
 add_subdirectory(types)
 add_subdirectory(util)
@@ -46,6 +47,10 @@ endforeach()
 
 foreach(src ${COMPLEMENT_SOURCES})
 	list(APPEND ALL_SOURCES "complement/${src}")
+endforeach()
+
+foreach(src ${DETERMINIZATION_SOURCES})
+	list(APPEND ALL_SOURCES "determinization/${src}")
 endforeach()
 
 foreach(src ${INCLUSION_SOURCES})
@@ -70,6 +75,7 @@ target_include_directories(kofola PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/algorithms
 	${CMAKE_CURRENT_SOURCE_DIR}/complement
+	${CMAKE_CURRENT_SOURCE_DIR}/determinization
 	${CMAKE_CURRENT_SOURCE_DIR}/inclusion
 	${CMAKE_CURRENT_SOURCE_DIR}/types
 	${CMAKE_CURRENT_SOURCE_DIR}/util

--- a/src/determinization/CMakeLists.txt
+++ b/src/determinization/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Determinization module
+set(DETERMINIZATION_SOURCES
+    determinize_tela.cpp
+)
+
+set(DETERMINIZATION_HEADERS
+    determinize_tela.hpp
+)
+
+# Make the sources available to parent scope
+set(DETERMINIZATION_SOURCES ${DETERMINIZATION_SOURCES} PARENT_SCOPE)
+set(DETERMINIZATION_HEADERS ${DETERMINIZATION_HEADERS} PARENT_SCOPE)

--- a/src/determinization/determinize_tela.cpp
+++ b/src/determinization/determinize_tela.cpp
@@ -2,13 +2,16 @@
 
 namespace kofola
 {
-    tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut)
-        : aut_(aut)
-    {
+    spot::twa_graph_ptr determinize_tela(const spot::twa_graph_ptr& aut) {
+        tela_determinize det(aut);
+        return det.run_new();
     }
 
-    spot::twa_graph_ptr tela_determinize::run_new()
-    {
+    tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut)
+        : aut_(aut) {
+    }
+
+    spot::twa_graph_ptr tela_determinize::run_new() {
         // Interface-only stub: determinization not implemented yet.
         return aut_;
     }

--- a/src/determinization/determinize_tela.cpp
+++ b/src/determinization/determinize_tela.cpp
@@ -1,0 +1,15 @@
+#include "determinize_tela.hpp"
+
+namespace kofola
+{
+    tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut)
+        : aut_(aut)
+    {
+    }
+
+    spot::twa_graph_ptr tela_determinize::run_new()
+    {
+        // Interface-only stub: determinization not implemented yet.
+        return aut_;
+    }
+}

--- a/src/determinization/determinize_tela.cpp
+++ b/src/determinization/determinize_tela.cpp
@@ -1,16 +1,29 @@
 #include "determinize_tela.hpp"
 
+#include "../complement/complement_sync.hpp"
+
 namespace kofola
 {
     spot::twa_graph_ptr determinize_tela(const spot::twa_graph_ptr& aut) {
-        auto scc = std::make_shared<spot::scc_info>(aut);
-        tela_determinize det(aut, std::move(scc));
+        auto scc = std::make_shared<spot::scc_info>(aut, spot::scc_info_options::ALL);
+
+        // SCC partitioning (via the same helper used by complementation).
+        // Return tuple items:
+        //  (0) `num_partitions`     - number of created partitions
+        //  (1) `part_to_type_map`   - partition index -> PartitionType
+        //  (2) `st_to_part_map`     - state index -> partition index
+        //  (3) `scc_to_part_map`    - SCC index -> partition index
+        //  (4) `part_to_acc_map`    - partition index -> restricted acceptance condition
+        auto partitions = helpers::tnba_complement::create_partitions(*scc, kofola::OPTIONS);
+
+        tela_determinize det(aut, std::move(scc), std::move(partitions));
         return det.run_new();
     }
 
     tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut,
-                                       std::shared_ptr<spot::scc_info> scc)
-        : aut_(aut), scc_(std::move(scc)) {
+                                       std::shared_ptr<spot::scc_info> scc,
+                                       kofola::scc_partitions_t partitions)
+        : aut_(aut), scc_(std::move(scc)), partitions_(std::move(partitions)) {
     }
 
     spot::twa_graph_ptr tela_determinize::run_new() {

--- a/src/determinization/determinize_tela.cpp
+++ b/src/determinization/determinize_tela.cpp
@@ -3,12 +3,14 @@
 namespace kofola
 {
     spot::twa_graph_ptr determinize_tela(const spot::twa_graph_ptr& aut) {
-        tela_determinize det(aut);
+        auto scc = std::make_shared<spot::scc_info>(aut);
+        tela_determinize det(aut, std::move(scc));
         return det.run_new();
     }
 
-    tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut)
-        : aut_(aut) {
+    tela_determinize::tela_determinize(const spot::twa_graph_ptr& aut,
+                                       std::shared_ptr<spot::scc_info> scc)
+        : aut_(aut), scc_(std::move(scc)) {
     }
 
     spot::twa_graph_ptr tela_determinize::run_new() {

--- a/src/determinization/determinize_tela.hpp
+++ b/src/determinization/determinize_tela.hpp
@@ -2,6 +2,9 @@
 
 // spot
 #include <spot/twa/twa.hh>
+#include <spot/twaalgos/sccinfo.hh>
+
+#include <memory>
 
 namespace kofola {
     /// Determinize a transition-based Emerson-Lei automaton (TELA).
@@ -15,9 +18,11 @@ namespace kofola {
     {
     private:
         spot::twa_graph_ptr aut_;
+        std::shared_ptr<spot::scc_info> scc_;
 
     public:
-        explicit tela_determinize(const spot::twa_graph_ptr& aut);
+        tela_determinize(const spot::twa_graph_ptr& aut,
+                         std::shared_ptr<spot::scc_info> scc);
 
         /// Run determinization; currently a stub returning the input automaton.
         spot::twa_graph_ptr run_new();

--- a/src/determinization/determinize_tela.hpp
+++ b/src/determinization/determinize_tela.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// spot
+#include <spot/twa/twa.hh>
+
+namespace kofola
+{
+    // Determinization of transition-based Emerson-Lei automata (TELA).
+    // Template/interface only: no determinization logic yet.
+    class tela_determinize
+    {
+    private:
+        spot::twa_graph_ptr aut_;
+
+    public:
+        explicit tela_determinize(const spot::twa_graph_ptr& aut);
+
+        /// Run determinization; currently a stub returning the input automaton.
+        spot::twa_graph_ptr run_new();
+    };
+}

--- a/src/determinization/determinize_tela.hpp
+++ b/src/determinization/determinize_tela.hpp
@@ -5,8 +5,17 @@
 #include <spot/twaalgos/sccinfo.hh>
 
 #include <memory>
+#include <tuple>
+
+#include "../util/helpers.hpp"
 
 namespace kofola {
+    using scc_partitions_t = std::tuple<size_t,
+            kofola::PartitionToTypeMap,
+            kofola::StateToPartitionMap,
+            kofola::SCCToPartitionMap,
+            kofola::PartitionToAccMap>;
+
     /// Determinize a transition-based Emerson-Lei automaton (TELA).
     ///
     /// This is currently a thin wrapper around `tela_determinize`.
@@ -19,10 +28,12 @@ namespace kofola {
     private:
         spot::twa_graph_ptr aut_;
         std::shared_ptr<spot::scc_info> scc_;
+        kofola::scc_partitions_t partitions_;
 
     public:
         tela_determinize(const spot::twa_graph_ptr& aut,
-                         std::shared_ptr<spot::scc_info> scc);
+                         std::shared_ptr<spot::scc_info> scc,
+                         kofola::scc_partitions_t partitions);
 
         /// Run determinization; currently a stub returning the input automaton.
         spot::twa_graph_ptr run_new();

--- a/src/determinization/determinize_tela.hpp
+++ b/src/determinization/determinize_tela.hpp
@@ -3,8 +3,12 @@
 // spot
 #include <spot/twa/twa.hh>
 
-namespace kofola
-{
+namespace kofola {
+    /// Determinize a transition-based Emerson-Lei automaton (TELA).
+    ///
+    /// This is currently a thin wrapper around `tela_determinize`.
+    spot::twa_graph_ptr determinize_tela(const spot::twa_graph_ptr& aut);
+
     // Determinization of transition-based Emerson-Lei automata (TELA).
     // Template/interface only: no determinization logic yet.
     class tela_determinize

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,8 +361,7 @@ int main(int argc, char *argv[])
 				} else if (options.operation == "type") {
 					assert(false);
 				} else if (options.operation == "determinize") {
-					kofola::tela_determinize det(aut);
-					spot::twa_graph_ptr result = det.run_new();
+					spot::twa_graph_ptr result = kofola::determinize_tela(aut);
 
 					spot::print_hoa(std::cout, result);
 					std::cout << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "inclusion/inclusion_check.hpp"
 #include "version.hpp"
 #include "complement/elevatorization.hpp"
+#include "determinization/determinize_tela.hpp"
 
 // standard library headers
 #include <unistd.h>
@@ -180,6 +181,7 @@ int process_args(int argc, char *argv[], kofola::options* params)
 	// command
 	args::Group operation_group(parser, "Operation:", args::Group::Validators::AtMostOne);
 	args::Flag complement_flag(operation_group, "complement", "complement the inputs (default)", {"complement"});
+	args::Flag det_flag(operation_group, "det", "determinize the inputs", {"det"});
 	args::Flag type_flag(operation_group, "type", "print out types of the inputs", {"type"});
 	args::Flag scc_types_flag(operation_group, "scc-types", "print out types of SCCs in the inputs", {"scc-types"});
 	args::ActionFlag version_flag(operation_group, "version", "print program version", {"version"}, print_version);
@@ -233,6 +235,8 @@ int process_args(int argc, char *argv[], kofola::options* params)
 
 	if (type_flag) {
 		params->operation = "type";
+	} else if (det_flag) {
+		params->operation = "determinize";
 	} else if (scc_types_flag) {
 		params->operation = "scc-types";
 	} else if (help_flag) {
@@ -356,6 +360,12 @@ int main(int argc, char *argv[])
 					std::cout << "\n";
 				} else if (options.operation == "type") {
 					assert(false);
+				} else if (options.operation == "determinize") {
+					kofola::tela_determinize det(aut);
+					spot::twa_graph_ptr result = det.run_new();
+
+					spot::print_hoa(std::cout, result);
+					std::cout << "\n";
 				} else if (options.operation == "scc-types") {
 					spot::scc_info si(aut, spot::scc_info_options::ALL);
 					std::string scc_types = helpers::get_scc_types(si);


### PR DESCRIPTION
This pull request introduces a new determinization feature for transition-based Emerson-Lei automata (TELA) in the project. The main changes include integrating a new `determinization` module, updating build scripts to support it, and adding a command-line option to invoke determinization. The determinization logic is currently a stub, acting as a placeholder for future implementation.