### PR TITLE
TELA: shared breakpoint refactoring

### DIFF
--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -150,13 +150,13 @@ check_macrostate check_macrostate::init_contexts() const {
  *         encountered or if `nondet_split_set` yields a non-binary
  *         partition.
  */
-std::vector<check_macrostate> check_macrostate::get_succ(
+std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   const bdd&                        bdd,
   bool                              resample,
-  NodeContext&                      parent_context) const {
+  NodeContext                       parent_context) const {
 
   if (this->is_leaf()) {
     return std::visit(
@@ -172,7 +172,8 @@ std::vector<check_macrostate> check_macrostate::get_succ(
   NodeContext local = !actual_ctx.is_mergable(parent_context) ? this->node_value().get_succ_context(resample) : actual_ctx;
   // we either take predecessor reference of reference to local; get_succ applied on leaves modifies 
   // the context reference 
-  NodeContext& context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
+  NodeContext context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
+  bool is_root = actual_ctx.is_mergable(parent_context);
 
   const auto node_type = this->type();
   const check_macrostate left_ms(this->opts_, base_tree(this->left()));
@@ -182,17 +183,23 @@ std::vector<check_macrostate> check_macrostate::get_succ(
     const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
     const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
 
-    return cartesian_product<check_macrostate, check_macrostate>(
+    return cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
       left_succ,
       right_succ,
-      [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
-        auto tmp = check_macrostate::make(opts, TreeType::And, l, r, local);
-        return tmp;
+      [opts = this->opts_, is_root](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+        NodeContext local{};
+        NodeContext merge = l.second.merge_contexts(r.second);
+        if(is_root) {
+          local = merge;
+          merge = NodeContext{};
+        }
+        auto tmp = check_macrostate::make(opts, TreeType::And, l.first, r.first, local);
+        return {tmp, merge};
       });
   }
 
   if (node_type == TreeType::Or) {
-    std::set<check_macrostate> out;
+    std::set<std::pair<check_macrostate, NodeContext>> out;
     const auto partitions = nondet_split_set(check_states, 2);
     for (const auto& part : partitions) {
       if (part.size() != 2) {
@@ -204,16 +211,22 @@ std::vector<check_macrostate> check_macrostate::get_succ(
       const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample, context);
 
       // TODO: it is not efficient to call reduce here
-      const auto combined = cartesian_product<check_macrostate, check_macrostate>(
+      const auto combined = cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
         left_succ,
         right_succ,
-        [opts = this->opts_, &local](const check_macrostate& l, const check_macrostate& r) {
-          auto tmp = check_macrostate::make(opts, TreeType::Or, l, r, local);
-          return tmp.reduce();
+        [opts = this->opts_, is_root](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+          NodeContext local{};
+          NodeContext merge = l.second.merge_contexts(r.second);
+          if(is_root) {
+            local = merge;
+            merge = NodeContext{};
+          }
+          auto tmp = check_macrostate::make(opts, TreeType::Or, l.first, r.first, local);
+          return { tmp.reduce(), merge };
         });
       out.insert(combined.begin(), combined.end());
     }
-    return std::vector<check_macrostate>(out.begin(), out.end());
+    return std::vector<std::pair<check_macrostate, NodeContext>>(out.begin(), out.end());
   }
 
   throw std::logic_error("check_macrostate::get_succ: unexpected internal node type");
@@ -530,14 +543,14 @@ std::string check_macrostate::to_string_impl(const base_tree& tree, bool show_sh
  *         successor states, or an empty vector if an accepting transition
  *         matching `color` is encountered (no successors).
  */
-std::vector<check_macrostate> fin_leaf::get_succ(
+std::vector<std::pair<check_macrostate, NodeContext>> fin_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   options_ptr                        opts,
   const bdd&                        bdd,
   bool                              resample,
-  NodeContext&                      context) const {
+  NodeContext                       context) const {
 
   (void)opts;
   (void)resample; // unused
@@ -554,7 +567,7 @@ std::vector<check_macrostate> fin_leaf::get_succ(
       }
     }
   }
-  return {check_macrostate::fin(std::move(opts), std::move(succs), this->color, this->id)};
+  return {{check_macrostate::fin(std::move(opts), std::move(succs), this->color, this->id), NodeContext{}}};
 }
 
 bool fin_leaf::is_satisfied() const {
@@ -587,26 +600,27 @@ bool fin_leaf::is_satisfied() const {
  * @return Vector containing a single `check_macrostate::inf` with the
  *         successor sets `(succs, succ_break)` as described above.
  */
-std::vector<check_macrostate> inf_leaf::get_succ(
+std::vector<std::pair<check_macrostate, NodeContext>> inf_leaf::get_succ(
   const spot::const_twa_graph_ptr&  aut,
   const spot::scc_info&             scc_info,
   const std::set<unsigned>&         check_states,
   options_ptr                       opts,
   const bdd&                        bdd,
   bool                              resample,
-  NodeContext&                      context) const {
+  NodeContext                      context) const {
 
   std::set<unsigned> st = get_set_union(this->track, check_states);
   std::set<unsigned> succs = kofola::get_all_successors_in_scc(aut, scc_info, st, bdd);
   std::set<unsigned> succ_break {};
 
+
   if(opts && opts->use_shared_breakpoint && context.type == NodeContextType::SHARED_BREAKPOINT) {
     if(context.leaf_id != this->id) {
-      return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+      return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), NodeContext{}}};
     }
     assert(!resample || context.state == NodeContextState::RESAMLE_LEAF);
     if(context.state == NodeContextState::GLOBAL_WAIT) {
-      return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+      return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), NodeContext{}}};
     } else if(context.state == NodeContextState::RESAMLE_LEAF) {
       succ_break = succs;
       if(context.leaf_id == this->id) {
@@ -631,7 +645,7 @@ std::vector<check_macrostate> inf_leaf::get_succ(
       succ_break.clear();
     } 
     
-    return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+    return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), context}};
   }
 
   if (!resample) {
@@ -646,11 +660,11 @@ std::vector<check_macrostate> inf_leaf::get_succ(
       }
     }
 
-    return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id)};
+    return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), context}};
   }
 
   auto succs_copy = succs;
-  return {check_macrostate::inf(std::move(opts), std::move(succs), std::move(succs_copy), this->color, this->id)};
+  return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succs_copy), this->color, this->id), context}};
 }
 
 bool inf_leaf::is_satisfied() const {
@@ -766,7 +780,7 @@ mstate_col_set complement_sd_inductive::get_succ_active(
 
   std::set<unsigned> succ_check = kofola::get_all_successors_in_scc(
       this->info_.aut_, this->info_.scc_info_, src_mst->check_, symbol);
-  std::vector<sd_inductive::check_macrostate> succ_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
+  auto succ_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
       this->info_.scc_info_, empty, symbol, false, context);
 
   if(src_mst->check_.empty() && src_mst->check_tree_.is_satisfied()) {

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -166,31 +166,30 @@ std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ
       this->leaf_value());
   }
 
-  // we get current context (for nodes not using meanungful contexts it is unique default context)
-  NodeContext actual_ctx = this->node_value().get_context();
-  // if parent context is not mergable with the parent == it is a root of a subtree where shared breakpoint is used
-  NodeContext local = !actual_ctx.is_mergable(parent_context) ? this->node_value().get_succ_context(resample) : actual_ctx;
-  // we either take predecessor reference of reference to local; get_succ applied on leaves modifies 
-  // the context reference 
-  NodeContext context  = this->opts_->use_shared_breakpoint ? local.merge_contexts(parent_context) : local;
-  bool is_root = actual_ctx.is_mergable(parent_context);
+  NodeContext context_sent = parent_context;
+  NodeContext actual_node_context = this->node_value().get_context();
+  bool is_root = actual_node_context.is_root(parent_context);
+  if(is_root) {
+    context_sent = this->node_value().get_succ_context(resample);
+    actual_node_context = context_sent;
+  }
 
   const auto node_type = this->type();
   const check_macrostate left_ms(this->opts_, base_tree(this->left()));
   const check_macrostate right_ms(this->opts_, base_tree(this->right()));
 
   if (node_type == TreeType::And) {
-    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
-    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context);
+    const auto left_succ = left_ms.get_succ(aut, scc_info, check_states, bdd, resample, context_sent);
+    const auto right_succ = right_ms.get_succ(aut, scc_info, check_states, bdd, resample, context_sent);
 
     return cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
       left_succ,
       right_succ,
-      [opts = this->opts_, is_root](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
-        NodeContext local{};
-        NodeContext merge = l.second.merge_contexts(r.second);
+      [opts = this->opts_, is_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+        NodeContext local = actual_node_context;
+        NodeContext merge = l.second.union_contexts(r.second);
         if(is_root) {
-          local = merge;
+          if(merge.type != NodeContextType::NONE) local = merge;
           merge = NodeContext{};
         }
         auto tmp = check_macrostate::make(opts, TreeType::And, l.first, r.first, local);
@@ -207,18 +206,18 @@ std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ
       }
       const auto& left_states = part[0];
       const auto& right_states = part[1];
-      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd, resample, context);
-      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample, context);
+      const auto left_succ = left_ms.get_succ(aut, scc_info, left_states, bdd, resample, context_sent);
+      const auto right_succ = right_ms.get_succ(aut, scc_info, right_states, bdd, resample, context_sent);
 
       // TODO: it is not efficient to call reduce here
       const auto combined = cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
         left_succ,
         right_succ,
-        [opts = this->opts_, is_root](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
-          NodeContext local{};
-          NodeContext merge = l.second.merge_contexts(r.second);
+        [opts = this->opts_, is_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+          NodeContext local = actual_node_context;
+          NodeContext merge = l.second.union_contexts(r.second);
           if(is_root) {
-            local = merge;
+            if(merge.type != NodeContextType::NONE) local = merge;
             merge = NodeContext{};
           }
           auto tmp = check_macrostate::make(opts, TreeType::Or, l.first, r.first, local);

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -793,23 +793,23 @@ mstate_col_set complement_sd_inductive::get_succ_active(
     }
     for(const auto& tree : succ_trees) {
       std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
-          full_scc_reach, tree));
+          full_scc_reach, tree.first));
       result.push_back({new_ms, colors});
     }
     return result;
   }
 
   if(!src_mst->check_.empty()) {
-    std::vector<sd_inductive::check_macrostate> succ_check_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
+    std::vector<std::pair<sd_inductive::check_macrostate, sd_inductive::NodeContext>> succ_check_trees = src_mst->check_tree_.get_succ(this->info_.aut_, 
       this->info_.scc_info_, src_mst->check_, symbol, true, context);
     for(const auto& tree : succ_trees) {
       std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
-          succ_check, tree));
+          succ_check, tree.first));
       result.push_back({new_ms, {}});
     }
     for(const auto& tree : succ_check_trees) {
       std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
-          empty, tree));
+          empty, tree.first));
       result.push_back({new_ms, {}});
     }
     return result;
@@ -817,7 +817,7 @@ mstate_col_set complement_sd_inductive::get_succ_active(
 
   for(const auto& tree : succ_trees) {
     std::shared_ptr<mstate> new_ms(new sd_inductive::mstate_sd_inductive(
-      empty, tree));
+      empty, tree.first));
     result.push_back({new_ms, {}});
   }
   return result;

--- a/src/algorithms/complement_alg_sd_inductive.cpp
+++ b/src/algorithms/complement_alg_sd_inductive.cpp
@@ -168,8 +168,8 @@ std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ
 
   NodeContext context_sent = parent_context;
   NodeContext actual_node_context = this->node_value().get_context();
-  bool is_root = actual_node_context.is_root(parent_context);
-  if(is_root) {
+  bool is_scope_root = actual_node_context.is_scope_root(parent_context);
+  if (is_scope_root) {
     context_sent = this->node_value().get_succ_context(resample);
     actual_node_context = context_sent;
   }
@@ -185,11 +185,11 @@ std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ
     return cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
       left_succ,
       right_succ,
-      [opts = this->opts_, is_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+      [opts = this->opts_, is_scope_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
         NodeContext local = actual_node_context;
         NodeContext merge = l.second.union_contexts(r.second);
-        if(is_root) {
-          if(merge.type != NodeContextType::NONE) local = merge;
+        if (is_scope_root) {
+          if (!merge.is_none()) local = merge;
           merge = NodeContext{};
         }
         auto tmp = check_macrostate::make(opts, TreeType::And, l.first, r.first, local);
@@ -213,11 +213,11 @@ std::vector<std::pair<check_macrostate, NodeContext>> check_macrostate::get_succ
       const auto combined = cartesian_product<std::pair<check_macrostate, NodeContext>, std::pair<check_macrostate, NodeContext>>(
         left_succ,
         right_succ,
-        [opts = this->opts_, is_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
+        [opts = this->opts_, is_scope_root, &actual_node_context](const std::pair<check_macrostate, NodeContext>& l, const std::pair<check_macrostate, NodeContext>& r) -> std::pair<check_macrostate, NodeContext> {
           NodeContext local = actual_node_context;
           NodeContext merge = l.second.union_contexts(r.second);
-          if(is_root) {
-            if(merge.type != NodeContextType::NONE) local = merge;
+          if (is_scope_root) {
+            if (!merge.is_none()) local = merge;
             merge = NodeContext{};
           }
           auto tmp = check_macrostate::make(opts, TreeType::Or, l.first, r.first, local);
@@ -613,19 +613,20 @@ std::vector<std::pair<check_macrostate, NodeContext>> inf_leaf::get_succ(
   std::set<unsigned> succ_break {};
 
 
-  if(opts && opts->use_shared_breakpoint && context.type == NodeContextType::SHARED_BREAKPOINT) {
-    if(context.leaf_id != this->id) {
+  if (opts && opts->use_shared_breakpoint && context.is_shared_breakpoint()) {
+    if (!context.targets_leaf(this->id)) {
       return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), NodeContext{}}};
     }
-    assert(!resample || context.state == NodeContextState::RESAMLE_LEAF);
-    if(context.state == NodeContextState::GLOBAL_WAIT) {
+    assert(!resample || context.state == NodeContextState::RESAMPLE_LEAF);
+    if (context.state == NodeContextState::GLOBAL_WAIT) {
       return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), NodeContext{}}};
-    } else if(context.state == NodeContextState::RESAMLE_LEAF) {
+    } else if (context.state == NodeContextState::RESAMPLE_LEAF) {
       succ_break = succs;
-      if(context.leaf_id == this->id) {
+      if (context.targets_leaf(this->id)) {
         context.state = NodeContextState::PROCESS_LEAF;
       }
     } else {
+      // PROCESS_LEAF: advance the breakpoint via the stored shared breakpoint set
       for (unsigned s : context.breakpoint) {
         for (const auto& t : aut->out(s)) {
           if (scc_info.scc_of(s) == scc_info.scc_of(t.dst) && bdd_implies(bdd, t.cond)) {
@@ -638,12 +639,12 @@ std::vector<std::pair<check_macrostate, NodeContext>> inf_leaf::get_succ(
       }
     }
 
-    if(context.leaf_id == this->id) {
-      // If using a shared breakpoint context, update it in-place.
+    if (context.targets_leaf(this->id)) {
+      // Store the new breakpoint in the shared context; the leaf's own breakpoint field stays clear.
       context.breakpoint = succ_break;
       succ_break.clear();
-    } 
-    
+    }
+
     return {{check_macrostate::inf(std::move(opts), std::move(succs), std::move(succ_break), this->color, this->id), context}};
   }
 

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -196,13 +196,23 @@ namespace sd_inductive {
      * @param predecessor Context from the parent node.
      * @return Reference to the context that should be used downstream.
      */
-    NodeContext& merge_contexts(NodeContext& predecessor) {
+    NodeContext merge_contexts(const NodeContext& predecessor) const {
       if (this->type == NodeContextType::NONE) {
         return *this;
       }
       if(this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT) {
         return predecessor;
       } 
+      return *this;
+    }
+
+    NodeContext union_contexts(const NodeContext& other) {
+      if(this->type == NodeContextType::NONE) {
+        return other;
+      }
+      if(other.type == NodeContextType::NONE) {
+        return *this;
+      }
       return *this;
     }
 
@@ -334,14 +344,14 @@ namespace sd_inductive {
       return std::strong_ordering::equal;
     }
 
-    std::vector<check_macrostate> get_succ(
+    std::vector<std::pair<check_macrostate, NodeContext>> get_succ(
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
-      NodeContext&                      context) const;
+      NodeContext                       context) const;
 
     bool is_satisfied() const;
   };
@@ -398,14 +408,14 @@ namespace sd_inductive {
       return std::strong_ordering::equal;
     }
 
-    std::vector<check_macrostate> get_succ(
+    std::vector<std::pair<check_macrostate, NodeContext>> get_succ(
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       options_ptr                        opts,
       const bdd&                        bdd,
       bool                              resample,
-      NodeContext&                      context) const;
+      NodeContext                       context) const;
 
     bool is_satisfied() const;
 
@@ -602,13 +612,13 @@ namespace sd_inductive {
     check_macrostate init_contexts() const;
 
     /// Compute successor macrostate(s) for this check tree node.
-    std::vector<check_macrostate> get_succ(
+    std::vector<std::pair<check_macrostate, NodeContext>> get_succ(
       const spot::const_twa_graph_ptr&  aut,
       const spot::scc_info&             scc_info,
       const std::set<unsigned>&         check_states,
       const bdd&                        bdd,
       bool                              resample,
-      NodeContext&                      parent_context) const;
+      NodeContext                       parent_context) const;
 
     /// Check whether this macrostate check tree is satisfied.
     bool is_satisfied() const;

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -50,7 +50,7 @@ namespace sd_inductive {
 
   enum class NodeContextState {
     GLOBAL_WAIT,
-    RESAMLE_LEAF,
+    RESAMPLE_LEAF,
     PROCESS_LEAF,
   };
 
@@ -76,57 +76,86 @@ namespace sd_inductive {
 
     std::set<unsigned> breakpoint {};
     unsigned leaf_id {0};
-    unsigned leaf_index {0};
-    std::vector<unsigned> leaf_ids {};
     NodeContextState state {NodeContextState::GLOBAL_WAIT};
+
+    // ----------------------------------------------------------------
+    // Predicates — prefer these over direct field comparisons in callers
+    // ----------------------------------------------------------------
+
+    /// True when this context carries no special optimization (default state).
+    bool is_none() const { return type == NodeContextType::NONE; }
+
+    /// True when this context runs the shared-breakpoint optimization.
+    bool is_shared_breakpoint() const { return type == NodeContextType::SHARED_BREAKPOINT; }
+
+    /// True when this context is currently targeting the leaf with the given @p id.
+    bool targets_leaf(unsigned id) const { return leaf_id == id; }
+
+    /**
+     * @brief True when the shared-breakpoint cycle for this And-node is complete.
+     *
+     * An And-node is cycle-complete when either the context is not a
+     * shared-breakpoint context at all, or the breakpoint is empty and the
+     * state machine has returned to `GLOBAL_WAIT`.
+     */
+    bool is_cycle_completed() const {
+      return !is_shared_breakpoint() ||
+             (breakpoint.empty() && state == NodeContextState::GLOBAL_WAIT);
+    }
+
+    // ----------------------------------------------------------------
+    // State-machine
+    // ----------------------------------------------------------------
 
     /**
      * @brief Compute the successor context for one transition step.
      *
-     * This method implements the small state machine used by the
-     * shared-breakpoint optimization.
-     *
-     * - If `type != SHARED_BREAKPOINT`, the context is returned unchanged.
-     * - In `GLOBAL_WAIT`, a `resample` request moves the context to
-     *   `RESAMLE_LEAF` (otherwise it stays in `GLOBAL_WAIT`).
-     * - In `PROCESS_LEAF`, the selected leaf is advanced when the breakpoint
-     *   becomes empty; when the leaf index wraps to 0, the state returns to
-     *   `GLOBAL_WAIT`.
+     * Implements the small state machine used by the shared-breakpoint
+     * optimization:
+     * - If not a `SHARED_BREAKPOINT` context, returns itself unchanged.
+     * - In `GLOBAL_WAIT`: a `resample` request advances to `RESAMPLE_LEAF`.
+     * - In `PROCESS_LEAF`: advances the leaf index when the breakpoint empties;
+     *   wrapping back to index 0 returns to `GLOBAL_WAIT`.
      *
      * @param resample Whether the caller requests a resampling step.
      * @return A copy of this context updated for the next step.
      */
     NodeContext get_succ_context(bool resample) const {
       NodeContext succ = *this;
-      if(this->type != NodeContextType::SHARED_BREAKPOINT) {
+      if (!this->is_shared_breakpoint()) {
         return succ;
       }
 
-      if(this->state == NodeContextState::GLOBAL_WAIT) {
-        if(resample) {
-          succ.state = NodeContextState::RESAMLE_LEAF;
+      if (this->state == NodeContextState::GLOBAL_WAIT) {
+        if (resample) {
+          succ.state = NodeContextState::RESAMPLE_LEAF;
         }
-        // else do nothing
-      } else if(this->state == NodeContextState::RESAMLE_LEAF) {
+        // else stay in GLOBAL_WAIT
+      } else if (this->state == NodeContextState::RESAMPLE_LEAF) {
         assert(false);
         return succ;
       } else {
-        if(succ.leaf_ids.size() > 0) {
-          succ.leaf_index = succ.leaf_index % succ.leaf_ids.size();
-          if(succ.breakpoint.empty()) {
-            succ.leaf_index = (succ.leaf_index + 1) % succ.leaf_ids.size();
-            if(succ.leaf_index == 0) {
+        // PROCESS_LEAF: advance the cyclic leaf pointer when breakpoint drains
+        if (succ.leaf_ids_.size() > 0) {
+          succ.leaf_index_ = succ.leaf_index_ % succ.leaf_ids_.size();
+          if (succ.breakpoint.empty()) {
+            succ.leaf_index_ = (succ.leaf_index_ + 1) % succ.leaf_ids_.size();
+            if (succ.leaf_index_ == 0) {
               succ.state = NodeContextState::GLOBAL_WAIT;
             } else {
-              succ.state = NodeContextState::RESAMLE_LEAF;
+              succ.state = NodeContextState::RESAMPLE_LEAF;
             }
           }
         }
-        succ.leaf_id = succ.leaf_ids[succ.leaf_index];
+        succ.leaf_id = succ.leaf_ids_[succ.leaf_index_];
       }
-      
+
       return succ;
     }
+
+    // ----------------------------------------------------------------
+    // Factory
+    // ----------------------------------------------------------------
 
     /**
      * @brief Build a shared-breakpoint context for a subtree.
@@ -135,101 +164,87 @@ namespace sd_inductive {
      * is an `And` node with at least one `Inf` leaf, initializes the returned
      * context as `SHARED_BREAKPOINT` and selects the first leaf ID.
      *
-     * @param t Type of the subtree root.
+     * @param t        Type of the subtree root.
      * @param subtree_ Subtree to inspect for `Inf` leaf IDs.
      * @return A freshly initialized context for that subtree.
      */
     static NodeContext create_subtree_sh_context(TreeType t, const check_macrostate& subtree_) {
       NodeContext ctx;
-      collect_inf_leaf_ids(subtree_, ctx.leaf_ids);
-      if(t == TreeType::And && ctx.leaf_ids.size() > 0) {
+      collect_inf_leaf_ids(subtree_, ctx.leaf_ids_);
+      if (t == TreeType::And && ctx.leaf_ids_.size() > 0) {
         ctx.type = NodeContextType::SHARED_BREAKPOINT;
-        ctx.leaf_id = ctx.leaf_ids[ctx.leaf_index % ctx.leaf_ids.size()];
+        ctx.leaf_id = ctx.leaf_ids_[ctx.leaf_index_ % ctx.leaf_ids_.size()];
       }
       return ctx;
     }
 
-    bool operator==(const NodeContext& other) const = default;
+    // ----------------------------------------------------------------
+    // Structural
+    // ----------------------------------------------------------------
 
-    std::strong_ordering operator<=>(const NodeContext& other) const {
-      if (this->type < other.type)
-        return std::strong_ordering::less;
-      if (other.type < this->type)
-        return std::strong_ordering::greater;
-
-      if (this->breakpoint < other.breakpoint)
-        return std::strong_ordering::less;
-      if (other.breakpoint < this->breakpoint)
-        return std::strong_ordering::greater;
-
-      if (this->leaf_id < other.leaf_id)
-        return std::strong_ordering::less;
-      if (other.leaf_id < this->leaf_id)
-        return std::strong_ordering::greater;
-
-      if (this->leaf_index < other.leaf_index)
-        return std::strong_ordering::less;
-      if (other.leaf_index < this->leaf_index)
-        return std::strong_ordering::greater;
-
-      if (this->leaf_ids < other.leaf_ids)
-        return std::strong_ordering::less;
-      if (other.leaf_ids < this->leaf_ids)
-        return std::strong_ordering::greater;
-
-      if (this->state < other.state)
-        return std::strong_ordering::less;
-      if (other.state < this->state)
-        return std::strong_ordering::greater;
-
-      return std::strong_ordering::equal;
+    /**
+     * @brief True when this context opens a new shared-breakpoint scope.
+     *
+     * A context is a scope root when it carries a shared-breakpoint type
+     * while its parent does not, i.e. this is the topmost And-node that
+     * introduces the optimization.
+     *
+     * @param parent Context from the enclosing (parent) node.
+     */
+    bool is_scope_root(const NodeContext& parent) const {
+      return is_shared_breakpoint() && !parent.is_shared_breakpoint();
     }
 
     /**
-     * @brief Merge this context with a predecessor context.
+     * @brief Combine this context with a sibling context coming from the
+     *        other child of an And/Or node.
      *
-     * Intended use: propagate a shared-breakpoint context top-down.
-     * If both this and @p predecessor are `SHARED_BREAKPOINT`, the predecessor
-     * is kept (so the shared-breakpoint state is effectively inherited).
-     * Otherwise this context is kept.
+     * `NONE` is the identity element: if either side is `NONE`, the other
+     * is returned.  When both sides carry a context, `*this` wins.
      *
-     * @param predecessor Context from the parent node.
-     * @return Reference to the context that should be used downstream.
+     * @param other Context returned by the sibling subtree.
+     * @return The combined context to propagate upward.
      */
-    NodeContext merge_contexts(const NodeContext& predecessor) const {
-      if (this->type == NodeContextType::NONE) {
-        return *this;
-      }
-      if(this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT) {
-        return predecessor;
-      } 
-      return *this;
-    }
-
     NodeContext union_contexts(const NodeContext& other) const {
-      if(this->type == NodeContextType::NONE) {
+      if (this->is_none()) {
         return other;
       }
-      if(other.type == NodeContextType::NONE) {
+      if (other.is_none()) {
         return *this;
       }
       return *this;
-    }
-
-    /**
-     * @brief Check whether this context can be merged with @p predecessor.
-     *
-     * Currently, contexts are mergeable iff both are `SHARED_BREAKPOINT`.
-     *
-     * @param predecessor Context from the parent node.
-     * @return `true` if the two contexts are considered mergeable.
-     */
-    bool is_root(NodeContext& predecessor) {
-      return this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type != NodeContextType::SHARED_BREAKPOINT;
     }
 
     void restrict_states(const std::set<unsigned>& forbidden) {
       this->breakpoint = get_set_difference(this->breakpoint, forbidden);
+    }
+
+    // ----------------------------------------------------------------
+    // Comparison & serialization
+    // ----------------------------------------------------------------
+
+    bool operator==(const NodeContext& other) const = default;
+
+    std::strong_ordering operator<=>(const NodeContext& other) const {
+      if (this->type < other.type) return std::strong_ordering::less;
+      if (other.type < this->type) return std::strong_ordering::greater;
+
+      if (this->breakpoint < other.breakpoint) return std::strong_ordering::less;
+      if (other.breakpoint < this->breakpoint) return std::strong_ordering::greater;
+
+      if (this->leaf_id < other.leaf_id) return std::strong_ordering::less;
+      if (other.leaf_id < this->leaf_id) return std::strong_ordering::greater;
+
+      if (this->leaf_index_ < other.leaf_index_) return std::strong_ordering::less;
+      if (other.leaf_index_ < this->leaf_index_) return std::strong_ordering::greater;
+
+      if (this->leaf_ids_ < other.leaf_ids_) return std::strong_ordering::less;
+      if (other.leaf_ids_ < this->leaf_ids_) return std::strong_ordering::greater;
+
+      if (this->state < other.state) return std::strong_ordering::less;
+      if (other.state < this->state) return std::strong_ordering::greater;
+
+      return std::strong_ordering::equal;
     }
 
     std::string to_string() const {
@@ -237,6 +252,12 @@ namespace sd_inductive {
       os << *this;
       return os.str();
     }
+
+  private:
+    /// Index of the currently active leaf inside `leaf_ids_`.
+    unsigned leaf_index_ {0};
+    /// Ordered list of `Inf` leaf IDs under the enclosing `And` node.
+    std::vector<unsigned> leaf_ids_ {};
   };
 
   inline std::ostream& operator<<(std::ostream& os, const NodeContext& ctx) {
@@ -275,8 +296,10 @@ namespace sd_inductive {
     bool operator==(const AndOrNode& other) const;
     std::strong_ordering operator<=>(const AndOrNode& other) const;
 
+    /// True when the shared-breakpoint cycle for this node has completed
+    /// (or the context is not a shared-breakpoint context at all).
     bool is_satisfied() const {
-      return (this->context.type != NodeContextType::SHARED_BREAKPOINT || this->context.breakpoint.empty()) && this->context.state == NodeContextState::GLOBAL_WAIT;
+      return this->context.is_cycle_completed();
     }
 
     NodeContext get_succ_context(bool resample) const {

--- a/src/algorithms/complement_alg_sd_inductive.hpp
+++ b/src/algorithms/complement_alg_sd_inductive.hpp
@@ -206,7 +206,7 @@ namespace sd_inductive {
       return *this;
     }
 
-    NodeContext union_contexts(const NodeContext& other) {
+    NodeContext union_contexts(const NodeContext& other) const {
       if(this->type == NodeContextType::NONE) {
         return other;
       }
@@ -224,8 +224,8 @@ namespace sd_inductive {
      * @param predecessor Context from the parent node.
      * @return `true` if the two contexts are considered mergeable.
      */
-    bool is_mergable(NodeContext& predecessor) {
-      return this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type == NodeContextType::SHARED_BREAKPOINT;
+    bool is_root(NodeContext& predecessor) {
+      return this->type == NodeContextType::SHARED_BREAKPOINT && predecessor.type != NodeContextType::SHARED_BREAKPOINT;
     }
 
     void restrict_states(const std::set<unsigned>& forbidden) {


### PR DESCRIPTION
This pull request refactors the handling of successor computation and context management in the `sd_inductive` algorithm. The changes update function signatures to consistently return both macrostate and context, introduce new predicates and state machine logic for context management, and fix naming and logic errors in the state transitions. These improvements make the code more robust and easier to maintain.